### PR TITLE
chore: add "type": "module" to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "marketplace",
     "wallet"
   ],
+  "type": "module",
   "repository": "github:derodero24/react-web3-icons",
   "homepage": "https://react-web3-icons-mu.vercel.app/",
   "main": "dist/index.cjs",


### PR DESCRIPTION
## Summary

- Add `"type": "module"` to root `package.json` to declare the package as ESM
- Eliminates the `MODULE_TYPELESS_PACKAGE_JSON` warning during builds

## Details

Node.js emits a warning when loading `tsdown.config.ts` because it has to double-parse the file (first as CJS, then as ESM) when the package type is unspecified. Setting `"type": "module"` tells Node.js to treat `.js`/`.ts` files as ESM by default, removing this overhead.

All dist outputs already use explicit file extensions (`.mjs` for ESM, `.cjs` for CJS), so this change has no impact on consumers.

## Test plan

- [x] `pnpm run build` succeeds and `MODULE_TYPELESS_PACKAGE_JSON` warning is gone
- [x] `pnpm run check` passes (133 files)
- [x] `pnpm test` passes (278 tests)
- [x] Example app `next build` succeeds

Closes #25