### PR TITLE
fix(example): use icon name as React key instead of array index

### DIFF
--- a/example/src/components/sections/IconTable.tsx
+++ b/example/src/components/sections/IconTable.tsx
@@ -72,8 +72,8 @@ export default function IconTable() {
       <SearchForm keyword={keyword} setKeyword={setKeyword} />
 
       <div className="mt-6 flex flex-wrap gap-x-3 gap-y-4">
-        {displayedIcons.map((icon, idx) => (
-          <div key={idx} className="relative">
+        {displayedIcons.map(icon => (
+          <div key={icon.name} className="relative">
             <button
               type="button"
               aria-label={`Copy ${icon.name}`}


### PR DESCRIPTION
## Summary

- Replace `key={idx}` with `key={icon.name}` in IconTable component
- Prevents potential rendering bugs when the list is filtered by keyword search, as React may incorrectly reuse DOM elements when indices shift

Closes #37