### PR TITLE
chore: enable parallel execution for pre-push hooks

### DIFF
--- a/lefthook.yml
+++ b/lefthook.yml
@@ -5,6 +5,7 @@ pre-commit:
       run: npx @biomejs/biome check --staged --no-errors-on-unmatched {staged_files}
 
 pre-push:
+  parallel: true
   commands:
     lint:
       run: pnpm run check


### PR DESCRIPTION
## Summary

- Add `parallel: true` to the pre-push section in lefthook.yml
- Lint, test, and build hooks now run concurrently instead of sequentially
- Reduces push wait time since these commands are independent of each other

Closes #39