### PR TITLE
chore: deduplicate Biome config using extends

### DIFF
--- a/example/biome.json
+++ b/example/biome.json
@@ -1,15 +1,9 @@
 {
   "$schema": "https://biomejs.dev/schemas/2.4.4/schema.json",
   "root": false,
+  "extends": ["../biome.json"],
   "files": {
     "includes": ["src/**"]
-  },
-  "formatter": {
-    "enabled": true,
-    "indentStyle": "space",
-    "indentWidth": 2,
-    "lineWidth": 80,
-    "lineEnding": "lf"
   },
   "css": {
     "parser": {
@@ -17,31 +11,12 @@
       "tailwindDirectives": true
     }
   },
-  "javascript": {
-    "formatter": {
-      "quoteStyle": "single",
-      "jsxQuoteStyle": "double",
-      "arrowParentheses": "asNeeded",
-      "trailingCommas": "all",
-      "semicolons": "always",
-      "bracketSpacing": true,
-      "bracketSameLine": false,
-      "quoteProperties": "asNeeded"
-    }
-  },
   "linter": {
-    "enabled": true,
     "domains": {
       "next": "recommended",
       "tailwind": "recommended"
     },
     "rules": {
-      "recommended": true,
-      "correctness": {
-        "noUnusedImports": "warn",
-        "noUnusedVariables": "warn",
-        "noUnusedFunctionParameters": "warn"
-      },
       "complexity": {
         "useLiteralKeys": "off"
       },
@@ -50,19 +25,11 @@
       },
       "style": {
         "noDefaultExport": "off",
-        "useImportType": "error",
-        "useExportType": "error"
+        "noNamespace": "off",
+        "useNumericSeparators": "off"
       },
       "suspicious": {
-        "noConsole": "warn"
-      }
-    }
-  },
-  "assist": {
-    "enabled": true,
-    "actions": {
-      "source": {
-        "organizeImports": "on"
+        "noArrayIndexKey": "off"
       }
     }
   }

--- a/example/src/components/sections/IconTable.tsx
+++ b/example/src/components/sections/IconTable.tsx
@@ -61,7 +61,6 @@ export default function IconTable() {
           2_000,
         );
       })
-      // biome-ignore lint/suspicious/noConsole: legitimate error reporting for clipboard API
       .catch(console.error);
   };
 


### PR DESCRIPTION
## Summary

- Replace duplicated settings in `example/biome.json` with `extends` from root config
- Formatter, JavaScript formatter, and assist settings are now inherited from the root
- Only example-specific overrides remain: Next.js domains, Tailwind CSS, and rules that differ from the strict root config
- Remove obsolete `biome-ignore` suppression comment in IconTable.tsx

### Before (69 lines)
Standalone config with fully duplicated formatter, javascript.formatter, and assist sections.

### After (36 lines)
Extends root config with only example-specific overrides:
- `noDefaultExport: off` (Next.js pages require default exports)
- `noNamespace: off` (env.d.ts type augmentation)
- `useLiteralKeys: off` / `noArrayIndexKey: off` / `useNumericSeparators: off`
- Next.js and Tailwind linter domains
- Tailwind CSS parser directives

Closes #38