### PR TITLE
chore: improve package metadata for tree-shaking and size

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,6 @@
   },
   "sideEffects": false,
   "files": [
-    "src",
     "dist"
   ],
   "scripts": {


### PR DESCRIPTION
## Summary
- Add `"sideEffects": false` to enable bundler tree-shaking for unused icons (#48)
- Remove `src` from `files` field since only `dist/` is needed by consumers (#50)

Source maps already embed `sourcesContent` inline, so debugging is unaffected by removing `src`.

**Package size**: 2.7 MB → 2.3 MB (15% reduction, 123 → 11 files)

Closes #48, closes #50