### PR TITLE
fix(chain): correct ArbitrumNovaMono viewBox to prevent path clipping

### DIFF
--- a/src/chain/Arbitrum.tsx
+++ b/src/chain/Arbitrum.tsx
@@ -216,7 +216,7 @@ export function ArbitrumNovaMono(props: IconProps) {
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
-      viewBox="262.47 200 975.06 1099.98"
+      viewBox="200 200 1100 1100"
       width="1em"
       height="1em"
       fill="currentColor"


### PR DESCRIPTION
## Summary

- Fix `ArbitrumNovaMono` viewBox from `"262.47 200 975.06 1099.98"` to `"200 200 1100 1100"` to match the colored `ArbitrumNova` variant
- The shared circle paths (`ARBNOVA_CIRCLE1`/`ARBNOVA_CIRCLE2`) span x=200 to x=1300, but the old viewBox only covered x=262.47 to x=1237.53, clipping both edges

## Verification

- `ArbitrumNovaMono2` does **not** have this issue — it shares `ArbitrumNova2Base` which already uses the correct viewBox
- `Arbitrum`/`ArbitrumMono` do **not** have this issue — their `ARB_BORDER` path fits exactly within their viewBox boundaries

Closes #61