### PR TITLE
fix: use absolute URL for README image so it renders on npm

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 This library provides SVG icons related to Web3.
 
-![icons](image/icons.png)
+![icons](https://raw.githubusercontent.com/derodero24/react-web3-icons/main/image/icons.png)
 
 ## Find icons
 


### PR DESCRIPTION
## Summary

- Switch the README icon preview image from a relative path (`image/icons.png`) to an absolute GitHub raw URL
- The `files` field in package.json only includes `dist/`, so the relative path was broken on npmjs.com

Closes #67