### PR TITLE
chore: add bundle size check to pre-push hooks

### DIFF
--- a/lefthook.yml
+++ b/lefthook.yml
@@ -12,6 +12,4 @@ pre-push:
     test:
       run: pnpm test
     build:
-      env:
-        CI: "true"
-      run: pnpm run build && pnpm run size
+      run: pnpm run build && CI=true pnpm run size


### PR DESCRIPTION
## Summary

- Add `size-limit` check after `build` in the lefthook pre-push hooks
- Set `CI` environment variable to prevent `size-limit` from entering interactive mode in the parallel hook runner

Closes #59

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Chores**
  * ビルドプロセスを最適化しました。プッシュ前のビルド手順に環境設定とビルドサイズ検証ステップを追加し、ビルド品質管理を強化しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->