### PR TITLE
ci: add dedicated TypeScript type-checking step

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -41,6 +41,9 @@ jobs:
       - name: Lint
         run: pnpm run check
 
+      - name: Typecheck
+        run: pnpm run typecheck
+
       - name: Test
         run: pnpm test -- --coverage
 

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -9,6 +9,8 @@ pre-push:
   commands:
     lint:
       run: pnpm run check
+    typecheck:
+      run: pnpm run typecheck
     test:
       run: pnpm test
     build:

--- a/package.json
+++ b/package.json
@@ -48,7 +48,8 @@
     "prepublishOnly": "pnpm run build",
     "size": "size-limit",
     "start": "tsdown --watch",
-    "test": "vitest run"
+    "test": "vitest run",
+    "typecheck": "tsc --noEmit"
   },
   "devDependencies": {
     "@biomejs/biome": "2.4.4",


### PR DESCRIPTION
## Summary

- Add `typecheck` script (`tsc --noEmit`) to `package.json`
- Add dedicated Typecheck step to CI workflow (`.github/workflows/main.yml`)
- Add `typecheck` to lefthook pre-push hooks (runs in parallel with lint, test, build)

This surfaces type errors earlier and independently of the build step.
The bundler (tsdown/esbuild) may not enforce the full `strictest` tsconfig,
so a dedicated `tsc --noEmit` check ensures comprehensive type safety.

Closes #53