### PR TITLE
chore!: narrow React peer dependency from >=16 to >=18

### DIFF
--- a/.changeset/narrow-react-peer-dep.md
+++ b/.changeset/narrow-react-peer-dep.md
@@ -1,0 +1,5 @@
+---
+"react-web3-icons": major
+---
+
+Narrow React peer dependency from `>=16` to `>=18`. React 16 and 17 are no longer supported. This enables modern React APIs such as `useId()` and aligns with the broader ecosystem.

--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "vitest": "^4.0.18"
   },
   "peerDependencies": {
-    "react": ">=16"
+    "react": ">=18"
   },
   "packageManager": "pnpm@10.13.1",
   "engines": {


### PR DESCRIPTION
## Summary

- Drop support for React 16 and 17 by narrowing the `peerDependencies.react` range from `>=16` to `>=18`
- This aligns the declared peer dependency with the actual test environment (React 19) and the broader ecosystem
- Enables modern React APIs such as `useId()` for SVG ID uniqueness (#57) and simplifies `forwardRef` handling (#51)

## Related issue

Closes #58

## Checklist

- [x] Lint passes (`pnpm run check`)
- [x] Tests pass (`pnpm test`)
- [x] Build succeeds (`pnpm run build`)
- [x] Changeset included (if `src/` changed): `pnpm changeset`