### PR TITLE
chore: add retroactive changeset for v1.8.0 release

### DIFF
--- a/.changeset/v1-8-0-retroactive.md
+++ b/.changeset/v1-8-0-retroactive.md
@@ -1,0 +1,12 @@
+---
+"react-web3-icons": minor
+---
+
+### What's Changed
+
+- Enable tree-shaking with `sideEffects: false` field in package.json
+- Exclude source files from npm package for smaller install size
+- Modernize TypeScript configuration (target ES2022, moduleResolution Bundler)
+- Optimize large SVG icon files with shared path constants
+- Fix ArbitrumNovaMono viewBox clipping issue
+- Fix README image not rendering on npm


### PR DESCRIPTION
## Summary

- Add a retroactive changeset file for the v1.8.0 release
- All v1.8.0 changes were merged to `main` before Changesets was adopted, so no changeset files exist for them
- This changeset triggers the Changesets workflow: once merged, the Release GitHub Action will create a "Version Packages" PR that bumps `package.json` from `1.7.0` to `1.8.0` and updates the CHANGELOG

## Changes included in v1.8.0

- Enable tree-shaking with `sideEffects: false` field in package.json
- Exclude source files from npm package for smaller install size
- Modernize TypeScript configuration (target ES2022, moduleResolution Bundler)
- Optimize large SVG icon files with shared path constants
- Fix ArbitrumNovaMono viewBox clipping issue
- Fix README image not rendering on npm

## Test plan

- [x] Changeset file follows the correct format (`"react-web3-icons": minor`)
- [x] All existing tests pass (291 tests)
- [x] Build succeeds and is within size limit (85.11 kB < 100 kB)
- [ ] After merging, verify the Changesets bot creates a "Version Packages" PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)