### PR TITLE
docs: enhance README with usage examples and API reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,41 +1,143 @@
 [![npm][npm-image]][npm-url]
+[![license][license-image]][license-url]
+[![bundle size][size-image]][size-url]
 
 [npm-image]: https://img.shields.io/npm/v/react-web3-icons?color=blue
 [npm-url]: https://www.npmjs.com/package/react-web3-icons
+[license-image]: https://img.shields.io/npm/l/react-web3-icons
+[license-url]: https://github.com/derodero24/react-web3-icons/blob/main/LICENSE
+[size-image]: https://img.shields.io/bundlephobia/minzip/react-web3-icons
+[size-url]: https://bundlephobia.com/package/react-web3-icons
 
 # React Web3 Icons
 
-This library provides SVG icons related to Web3.
+A comprehensive React SVG icon library for Web3 — blockchains, wallets, DEXs, tokens, and more.
 
 ![icons](https://raw.githubusercontent.com/derodero24/react-web3-icons/main/image/icons.png)
 
-## Find icons
+**[Browse all icons](https://react-web3-icons-mu.vercel.app/)**
 
-https://react-web3-icons-mu.vercel.app/
+## Features
+
+- 130+ icons across 13 categories
+- Colored and monochrome variants for every icon
+- Tree-shakeable — only import what you use (`sideEffects: false`)
+- Scales with font size (`1em` default)
+- Full TypeScript support
+- Works with React 18+
 
 ## Install
 
 ```sh
-npm install react-web3-icons  # for npm users
-yarn add react-web3-icons     # for yarn users
-pnpm add react-web3-icons     # for pnpm users
+npm install react-web3-icons
+```
+
+Or with other package managers:
+
+```sh
+yarn add react-web3-icons
+pnpm add react-web3-icons
 ```
 
 ## Quick Start
 
-```ts
-import { Btc, BtcMono } from 'react-web3-icons';
+```tsx
+import { Ethereum, EthereumMono } from 'react-web3-icons';
 
 function App() {
   return (
     <div>
-      <Btc style={{ fontSize: '1.5rem' }} />
-      <BtcMono style={{ color: '#1f2937', fontSize: '1.5rem' }} />
+      {/* Colored icon — renders official brand colors */}
+      <Ethereum />
+
+      {/* Mono icon — inherits CSS color */}
+      <EthereumMono style={{ color: '#6366f1' }} />
     </div>
   );
 }
 ```
 
-## Contribution
+## Usage
 
-We welcome your contributions! Please see [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines.
+### Sizing
+
+Icons default to `1em`, so they scale with the surrounding font size:
+
+```tsx
+<Ethereum style={{ fontSize: '2rem' }} />
+```
+
+You can also set explicit dimensions:
+
+```tsx
+<Ethereum width={32} height={32} />
+```
+
+### Monochrome Variants
+
+Every icon has a `Mono` variant that uses `currentColor`, making it easy to match your app's theme:
+
+```tsx
+<BitcoinMono style={{ color: 'white' }} />
+<BitcoinMono className="text-gray-500" /> {/* Tailwind */}
+```
+
+### Accessibility
+
+Add a `title` prop for screen reader support:
+
+```tsx
+<Ethereum title="Ethereum" />
+```
+
+When no `title` is provided, the icon is treated as decorative.
+
+### All Standard SVG Props
+
+Icons accept all standard SVG attributes:
+
+```tsx
+<Ethereum className="my-icon" style={{ opacity: 0.8 }} onClick={handleClick} />
+```
+
+## Icon Categories
+
+| Category | Description | Examples |
+| --- | --- | --- |
+| `chain` | L1/L2 blockchains | Ethereum, Arbitrum, Polygon, Solana |
+| `coin` | Cryptocurrencies & tokens | Bitcoin, Doge, USDT, USDC |
+| `wallet` | Wallet apps | MetaMask, Phantom, Rainbow |
+| `dex` | Decentralized exchanges | Uniswap, SushiSwap, PancakeSwap |
+| `exchange` | Centralized exchanges | Binance, Coinbase, Kraken |
+| `marketplace` | NFT marketplaces | OpenSea, Rarible, LooksRare |
+| `devtool` | Developer tools | Hardhat, Truffle, Foundry |
+| `explorer` | Block explorers | Etherscan, Blockscout |
+| `node` | Node providers | Alchemy, Infura, QuickNode |
+| `storage` | Decentralized storage | IPFS, Arweave, Filecoin |
+| `domain` | Domain services | ENS, Unstoppable Domains |
+| `portfolio` | Portfolio trackers | DeBank, Zapper |
+| `tracker` | Analytics & tracking | DeFi Llama, Dune |
+
+Browse the full list at the **[demo site](https://react-web3-icons-mu.vercel.app/)**.
+
+## Props
+
+All icons extend `SVGAttributes<SVGElement>` with the following additions:
+
+| Prop | Type | Default | Description |
+| --- | --- | --- | --- |
+| `title` | `string` | — | Accessible title rendered as `<title>` inside the SVG |
+| `width` | `string \| number` | `"1em"` | Icon width |
+| `height` | `string \| number` | `"1em"` | Icon height |
+| `className` | `string` | — | CSS class name |
+| `style` | `CSSProperties` | — | Inline styles |
+
+Plus all standard SVG attributes (`fill`, `stroke`, `opacity`, `onClick`, etc.).
+
+## Contributing
+
+We welcome contributions! Please see [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines on adding icons, the SVG optimization pipeline, and submitting pull requests.
+
+## License
+
+[MIT](LICENSE)


### PR DESCRIPTION
## Summary

Closes #32

- Add license and bundle size badges
- Expand usage section with sizing, mono variants, accessibility, and SVG props examples
- Add icon categories table covering all 13 categories with descriptions and examples
- Document the `IconProps` type with a props table
- Link to the demo site for browsing icons

## Test plan

- [x] `pnpm run check` passes
- [x] `pnpm test` passes
- [x] Verified all links and badge URLs resolve correctly
- [x] README renders correctly in GitHub markdown preview

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **ドキュメンテーション**
  * READMEを拡充し、サイズ指定、寸法プロパティ、単色バリアントなど包括的な使用ガイドを追加。
  * 複数のパッケージマネージャーオプションを含む改善されたインストール手順を提供。
  * より詳細な情報とデモサイトリンク付きのアイコンカテゴリテーブルを改善。
  * アクセシビリティガイダンスとSVGプロパティドキュメンテーションを追加。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->