### PR TITLE
chore: add .claude/ to .gitignore to ignore local worktree noise

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,7 @@ node_modules
 .next
 dist
 coverage
+
+# Claude Code local files
 CLAUDE.md
+.claude/


### PR DESCRIPTION
## Summary

- Add `.claude/` to `.gitignore` so that `.claude/worktrees/` and other local Claude Code files no longer appear as untracked in `git status`
- Group the existing `CLAUDE.md` entry under a `# Claude Code local files` comment

## Related issue

Closes #96

## Checklist

- [x] Parent worktree no longer shows `.claude/worktrees/*` as untracked
- [x] Ignore strategy does not affect published package contents (`.claude/` is not in `src/`)
- [x] No changeset needed (tooling-only change, no `src/` modifications)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **その他**
  * ローカル開発環境の設定ファイルが無視されるよう設定を追加しました。これにより、個人の開発環境設定がリポジトリに含まれなくなります。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->