### PR TITLE
test(vitest): exclude local worktrees from discovery

### DIFF
--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,8 +1,9 @@
-import { defineConfig } from 'vitest/config';
+import { configDefaults, defineConfig } from 'vitest/config';
 
 export default defineConfig({
   test: {
     environment: 'jsdom',
+    exclude: [...configDefaults.exclude, '**/.claude/**'],
     coverage: {
       provider: 'v8',
       reporter: ['text', 'lcov'],


### PR DESCRIPTION
## Summary
- preserve Vitest defaults by importing `configDefaults`
- add `**/.claude/**` to `test.exclude` so local Claude worktrees are not discovered
- keep test behavior unchanged for repository-root tests

## Related issue
Closes #110

## Checklist
- [x] Lint passes (`pnpm run check`)
- [x] Tests pass (`pnpm test`)
- [ ] Build succeeds (`pnpm run build`)
- [ ] Changeset included (if `src/` changed): `pnpm changeset`