### PR TITLE
chore(hooks): run pre-commit Biome via pnpm exec

### DIFF
--- a/lefthook.yml
+++ b/lefthook.yml
@@ -2,7 +2,7 @@ pre-commit:
   commands:
     biome:
       glob: '*.{js,ts,jsx,tsx,json,css}'
-      run: npx @biomejs/biome check --staged --no-errors-on-unmatched {staged_files}
+      run: pnpm exec biome check --staged --no-errors-on-unmatched {staged_files}
 
 pre-push:
   parallel: true


### PR DESCRIPTION
## Summary
- replace `npx @biomejs/biome` in `lefthook.yml` pre-commit with `pnpm exec biome`
- keep the existing staged-file Biome check behavior unchanged
- make hook execution use project-managed dependency versions

## Related issue
Closes #113

## Checklist
- [x] Lint passes (`pnpm run check`)
- [ ] Tests pass (`pnpm test`)
- [ ] Build succeeds (`pnpm run build`)
- [ ] Changeset included (if `src/` changed): `pnpm changeset`