### PR TITLE
fix(portfolio): add forwardRef wrappers and neutralize gitignore comment

### DIFF
--- a/.changeset/fix-coinpanda-forwardref.md
+++ b/.changeset/fix-coinpanda-forwardref.md
@@ -1,0 +1,5 @@
+---
+"react-web3-icons": patch
+---
+
+Add missing forwardRef wrappers to Coinpanda2, Coinpanda3, CoinpandaMono2, and CoinpandaMono3

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,6 @@ node_modules
 dist
 coverage
 
-# Claude Code local files
+# Local development files
 CLAUDE.md
 .claude/

--- a/src/portfolio/Coinpanda.tsx
+++ b/src/portfolio/Coinpanda.tsx
@@ -69,13 +69,17 @@ const CoinpandaBase2 = forwardRef(
 );
 CoinpandaBase2.displayName = 'CoinpandaBase2';
 
-export function Coinpanda2(props: IconProps) {
-  return <CoinpandaBase2 background="circle" {...props} />;
-}
+export const Coinpanda2 = forwardRef<SVGSVGElement, IconProps>(
+  function Coinpanda2(props, ref) {
+    return <CoinpandaBase2 background="circle" {...props} ref={ref} />;
+  },
+);
 
-export function Coinpanda3(props: IconProps) {
-  return <CoinpandaBase2 background="rect" {...props} />;
-}
+export const Coinpanda3 = forwardRef<SVGSVGElement, IconProps>(
+  function Coinpanda3(props, ref) {
+    return <CoinpandaBase2 background="rect" {...props} ref={ref} />;
+  },
+);
 
 const CoinpandaMonoBase = forwardRef(
   (
@@ -128,10 +132,14 @@ const CoinpandaMonoBase = forwardRef(
 );
 CoinpandaMonoBase.displayName = 'CoinpandaMonoBase';
 
-export function CoinpandaMono2(props: IconProps) {
-  return <CoinpandaMonoBase background="circle" {...props} />;
-}
+export const CoinpandaMono2 = forwardRef<SVGSVGElement, IconProps>(
+  function CoinpandaMono2(props, ref) {
+    return <CoinpandaMonoBase background="circle" {...props} ref={ref} />;
+  },
+);
 
-export function CoinpandaMono3(props: IconProps) {
-  return <CoinpandaMonoBase background="rect" {...props} />;
-}
+export const CoinpandaMono3 = forwardRef<SVGSVGElement, IconProps>(
+  function CoinpandaMono3(props, ref) {
+    return <CoinpandaMonoBase background="rect" {...props} ref={ref} />;
+  },
+);


### PR DESCRIPTION
## Summary

- Wrap `Coinpanda2`, `Coinpanda3`, `CoinpandaMono2`, and `CoinpandaMono3` with `forwardRef` to match the pattern used by Coinbase, Bscscan, and Solscan wrappers — prevents silent ref drops in React 18
- Replace tool-specific `.gitignore` comment with neutral wording

## Related issue

Closes #128

## Checklist

- [x] Biome lint passes
- [x] TypeScript type check passes
- [x] All 486 tests pass
- [x] Build succeeds
- [x] Size limits pass
- [x] Changeset included (patch)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Bug Fixes**
  * Coinpandaアイコンコンポーネントが参照転送に対応しました。親コンポーネントから基底のSVG要素へのアクセスが可能になります。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->