### PR TITLE
fix(example): pass initial value to useRef for React 19 compatibility

### DIFF
--- a/example/src/components/sections/IconTable.tsx
+++ b/example/src/components/sections/IconTable.tsx
@@ -24,7 +24,9 @@ export default function IconTable() {
   const [tipShowed, setTipShowed] = useState<Record<string, boolean>>({});
   const [copyStatus, setCopyStatus] = useState('');
   const timers = useRef<Record<string, ReturnType<typeof setTimeout>>>({});
-  const statusTimer = useRef<ReturnType<typeof setTimeout>>();
+  const statusTimer = useRef<ReturnType<typeof setTimeout> | undefined>(
+    undefined,
+  );
 
   useEffect(() => {
     return () => {


### PR DESCRIPTION
## Summary

- Pass explicit `undefined` initial value to `useRef<ReturnType<typeof setTimeout>>()` in `IconTable.tsx`
- React 19 types require an initial argument for `useRef`, causing a TypeScript build failure
- This build failure prevented Vercel from deploying updates after the Tailwind v4 PostCSS fix (#97), leaving the production site stuck on a broken CSS-less deployment

## Checklist

- [x] `pnpm run check` passed
- [x] `pnpm run typecheck` passed
- [x] `pnpm test` passed (486 tests)
- [x] `pnpm run build` passed
- [x] `pnpm run size` passed (all within limits)
- [x] Local production build verified with correct styling via Chrome DevTools
- [ ] No changeset needed (`example/` only)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **リファクタリング**
  * コンポーネントの内部型定義を改善し、より堅牢なコード構造を実現しました。ユーザー向けの機能や動作に変更はありません。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->