### PR TITLE
docs: define icon lifecycle policy for rebrands and deprecations

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -119,7 +119,7 @@ Use this policy when an icon project rebrands or an export name must change.
 
 - The current official name becomes the canonical export (for example, `Safe`).
 - The previous public name remains as a re-export alias in the same category (for example, `GnosisSafe`).
-- Alias exports must include `/** @deprecated Use \`NewName\` instead. */` JSDoc comments.
+- Alias exports must include ``/** @deprecated Use `NewName` instead. */`` JSDoc comments.
 - Keep behavior identical by re-exporting the canonical component instead of duplicating SVG markup.
 
 ### Deprecation and removal timing

--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ We welcome contributions! Please see [CONTRIBUTING.md](CONTRIBUTING.md) for guid
 
 ## Icon Lifecycle Policy
 
-When icon brands rename (for example, `GnosisSafe` -> `Safe`, `Matic` -> `Pol`), this project keeps backward compatibility by shipping deprecated aliases.
+When icon brands are renamed (for example, `GnosisSafe` -> `Safe`, `Matic` -> `Pol`), this project keeps backward compatibility by shipping deprecated aliases.
 
 - Canonical exports follow the current official brand name.
 - Deprecated aliases stay available for at least one minor release and at least 90 days.


### PR DESCRIPTION
## Summary

- add a documented icon lifecycle policy for rebrands/deprecations in `CONTRIBUTING.md`
- define rename strategy, deprecation window, removal timing, release-note requirements, and required compatibility tests
- add a README summary section with concrete examples (`GnosisSafe` -> `Safe`, `Matic` -> `Pol`) and a link to the full policy

## Related issue

Closes #116

## Icon source verification (required for icon add/update PRs)

N/A (docs-only change)

- Official source URL(s): N/A
- Brand guideline / usage reference: N/A
- Manual edits beyond SVGO (if any): N/A

## Checklist

- [ ] Lint passes (`pnpm run check`) *(blocked locally: Node is `v18.17.1`, repo requires `^20.19.0 || >=22.12.0`)*
- [ ] Tests pass (`pnpm test`) *(blocked locally: Node is `v18.17.1`, repo requires `^20.19.0 || >=22.12.0`)*
- [ ] Build succeeds (`pnpm run build`) *(blocked locally: Node is `v18.17.1`, repo requires `^20.19.0 || >=22.12.0`)*
- [x] Changeset included (if `src/` changed): `pnpm changeset` *(not required; `src/` unchanged)*
- [x] Official icon source and usage context documented above (or N/A)
- [x] Default icon geometry/colors match official asset (or N/A)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **ドキュメンテーション**
  * アイコンライフサイクルポリシーに関する新しいドキュメントを追加しました。
  * 廃止予定と削除のタイムラインに関するガイドラインを追加しました。
  * 後方互換性と非推奨エイリアスに関する情報を更新しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->