### PR TITLE
fix(exchange): update Bybit viewBox to match current official logo

### DIFF
--- a/.changeset/fix-bybit-viewbox.md
+++ b/.changeset/fix-bybit-viewbox.md
@@ -1,0 +1,5 @@
+---
+"react-web3-icons": patch
+---
+
+fix(exchange): update Bybit viewBox to match current official logo dimensions

--- a/src/exchange/Bybit.tsx
+++ b/src/exchange/Bybit.tsx
@@ -27,7 +27,7 @@ export const Bybit = forwardRef<SVGSVGElement, BybitProps>(function Bybit(
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
-      viewBox="0 3 87 29"
+      viewBox="0 0 87 34"
       width={width ?? size}
       height={height ?? size}
       aria-hidden={isDecorative || undefined}
@@ -63,7 +63,7 @@ export const BybitLight = forwardRef<SVGSVGElement, BybitProps>(
     return (
       <svg
         xmlns="http://www.w3.org/2000/svg"
-        viewBox="0 3 87 29"
+        viewBox="0 0 87 34"
         width={width ?? size}
         height={height ?? size}
         aria-hidden={isDecorative || undefined}
@@ -101,7 +101,7 @@ export const BybitMono = forwardRef<SVGSVGElement, BybitProps>(
     return (
       <svg
         xmlns="http://www.w3.org/2000/svg"
-        viewBox="0 3 87 29"
+        viewBox="0 0 87 34"
         width={width ?? size}
         height={height ?? size}
         aria-hidden={isDecorative || undefined}


### PR DESCRIPTION
## Summary

- Update `viewBox` from `0 3 87 29` to `0 0 87 34` in `Bybit`, `BybitLight`, and `BybitMono` components
- Matches the dimensions of the current official Bybit logo (87×34)
- Path shapes are unchanged; the old viewBox was cropping the logo vertically

## Related issue

Closes #217

## Checklist

- [x] Visual comparison confirmed (before/after screenshots reviewed)
- [x] All tests passing (500/500)
- [x] Lint and typecheck passing
- [x] Changeset added