### PR TITLE
feat(example): CSS Grid layout, variant toggle, empty state, and footer

### DIFF
--- a/example/src/app/layout.tsx
+++ b/example/src/app/layout.tsx
@@ -3,6 +3,7 @@ import '../styles/global.css';
 import type { Metadata } from 'next';
 import { Noto_Sans, Orbitron } from 'next/font/google';
 import type { ReactNode } from 'react';
+import Footer from '../components/sections/Footer';
 import Header from '../components/sections/Header';
 import { Providers } from './providers';
 
@@ -68,7 +69,8 @@ export default function RootLayout({ children }: { children: ReactNode }) {
         <Providers>
           <div className="flex min-h-svh flex-col">
             <Header />
-            <main>{children}</main>
+            <main className="flex-1">{children}</main>
+            <Footer />
           </div>
         </Providers>
       </body>

--- a/example/src/components/sections/Footer.tsx
+++ b/example/src/components/sections/Footer.tsx
@@ -1,0 +1,92 @@
+'use client';
+
+import { useState } from 'react';
+import pkg from '../../../../package.json';
+
+export default function Footer() {
+  const [copied, setCopied] = useState(false);
+
+  const installCmd = 'npm i react-web3-icons';
+
+  const copyInstall = () => {
+    navigator.clipboard
+      .writeText(installCmd)
+      .then(() => {
+        setCopied(true);
+        setTimeout(() => setCopied(false), 1_500);
+      })
+      // biome-ignore lint/suspicious/noConsole: legitimate error reporting for clipboard API
+      .catch(console.error);
+  };
+
+  return (
+    <footer className="mt-auto border-t border-gray-200 px-4 py-5 text-sm text-gray-500 dark:border-gray-600 dark:text-gray-400 sm:px-6">
+      <div className="flex flex-col items-center gap-3 sm:flex-row sm:justify-between">
+        <div className="flex items-center gap-3">
+          <button
+            type="button"
+            onClick={copyInstall}
+            aria-label="Copy install command"
+            className="flex items-center gap-2 rounded-md border border-gray-200 bg-gray-50 px-3 py-1.5 font-mono text-xs transition-colors hover:bg-gray-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 dark:border-gray-600 dark:bg-gray-700 dark:hover:bg-gray-600"
+          >
+            <span className="select-all">{installCmd}</span>
+            {copied ? (
+              <svg
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth={2.5}
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                width="1em"
+                height="1em"
+                className="text-green-500"
+                aria-hidden="true"
+              >
+                <polyline points="20 6 9 17 4 12" />
+              </svg>
+            ) : (
+              <svg
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth={2}
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                width="1em"
+                height="1em"
+                className="opacity-50"
+                aria-hidden="true"
+              >
+                <rect width="14" height="14" x="8" y="8" rx="2" ry="2" />
+                <path d="M4 16c-1.1 0-2-.9-2-2V4c0-1.1.9-2 2-2h10c1.1 0 2 .9 2 2" />
+              </svg>
+            )}
+          </button>
+          <span>v{pkg.version}</span>
+          <span>·</span>
+          <span>MIT</span>
+        </div>
+
+        <div className="flex items-center gap-4">
+          <a
+            href="https://github.com/derodero24/react-web3-icons"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="hover:text-gray-800 dark:hover:text-gray-200"
+          >
+            GitHub
+          </a>
+          <a
+            href="https://www.npmjs.com/package/react-web3-icons"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="hover:text-gray-800 dark:hover:text-gray-200"
+          >
+            npm
+          </a>
+        </div>
+      </div>
+    </footer>
+  );
+}

--- a/example/src/components/sections/IconTable.tsx
+++ b/example/src/components/sections/IconTable.tsx
@@ -18,9 +18,26 @@ const icons = iconModules as unknown as Record<
   ComponentType<{ className?: string }>
 >;
 
+type Variant = 'all' | 'colored' | 'mono';
+
+const VARIANT_LABELS: Record<Variant, string> = {
+  all: 'All',
+  colored: 'Colored',
+  mono: 'Mono',
+};
+
+const VARIANTS: Variant[] = ['all', 'colored', 'mono'];
+
+function filterByVariant(name: string, variant: Variant): boolean {
+  if (variant === 'mono') return name.endsWith('Mono');
+  if (variant === 'colored') return !name.endsWith('Mono');
+  return true;
+}
+
 export default function IconTable() {
   const searchParams = useSearchParams();
   const [keyword, setKeyword] = useState('');
+  const [variant, setVariant] = useState<Variant>('all');
   const [copiedName, setCopiedName] = useState<string | null>(null);
   const [copyStatus, setCopyStatus] = useState('');
   const copiedTimer = useRef<ReturnType<typeof setTimeout> | undefined>(
@@ -46,9 +63,12 @@ export default function IconTable() {
     return 'all';
   }, [searchParams]);
 
+  const categoryIcons = REACT_WEB3_ICONS[category];
+
   const displayedIcons = useMemo(
     () =>
-      REACT_WEB3_ICONS[category]
+      categoryIcons
+        .filter(name => filterByVariant(name, variant))
         .filter(name => name.toLowerCase().includes(keyword.toLowerCase()))
         .map(name => ({
           name,
@@ -56,7 +76,7 @@ export default function IconTable() {
             className?: string;
           }>,
         })),
-    [category, keyword],
+    [categoryIcons, keyword, variant],
   );
 
   const copy = (value: string) => {
@@ -74,23 +94,49 @@ export default function IconTable() {
       .catch(console.error);
   };
 
-  const totalCount = REACT_WEB3_ICONS[category].length;
+  const totalCount = categoryIcons.length;
   const resultCount = displayedIcons.length;
   const resultsText = keyword
     ? `${resultCount} of ${totalCount} icons`
     : `${totalCount} icons`;
 
+  const isCategoryEmpty = totalCount === 0;
+  const isSearchEmpty = !isCategoryEmpty && resultCount === 0;
+
   return (
     <section
       aria-label={`${category} icons`}
-      className="relative mb-24 px-4 pt-6 sm:px-6 lg:px-8"
+      className="relative mb-6 px-4 pt-6 sm:px-6 lg:px-8"
     >
-      <SearchForm
-        keyword={keyword}
-        setKeyword={setKeyword}
-        resultCount={resultCount}
-        totalCount={totalCount}
-      />
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:gap-4">
+        <div className="flex-1">
+          <SearchForm
+            keyword={keyword}
+            setKeyword={setKeyword}
+            resultCount={resultCount}
+            totalCount={totalCount}
+          />
+        </div>
+
+        <fieldset className="flex shrink-0 overflow-hidden rounded-xl border border-gray-200 bg-white shadow-sm dark:border-gray-500 dark:bg-gray-600">
+          <legend className="sr-only">Icon variant filter</legend>
+          {VARIANTS.map(v => (
+            <button
+              key={v}
+              type="button"
+              onClick={() => setVariant(v)}
+              aria-pressed={variant === v}
+              className={`h-12 px-4 text-sm font-medium transition-colors duration-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-blue-500 ${
+                variant === v
+                  ? 'bg-gray-800 text-white dark:bg-gray-100 dark:text-gray-900'
+                  : 'text-gray-600 hover:bg-gray-100 dark:text-gray-200 dark:hover:bg-gray-500'
+              }`}
+            >
+              {VARIANT_LABELS[v]}
+            </button>
+          ))}
+        </fieldset>
+      </div>
 
       <p id="icon-count" className="sr-only" aria-live="polite">
         {resultsText}
@@ -100,48 +146,97 @@ export default function IconTable() {
         {copyStatus}
       </output>
 
-      <div className="mt-6 flex flex-wrap gap-x-3 gap-y-4">
-        {displayedIcons.map(icon => {
-          const isCopied = copiedName === icon.name;
-          return (
-            <div key={icon.name} className="relative">
-              <button
-                type="button"
-                aria-label={`Copy ${icon.name}`}
-                className="group mx-auto flex aspect-square w-20 cursor-pointer items-center justify-center rounded-lg border border-gray-200 bg-white shadow-sm transition-all duration-150 ease-out hover:scale-[1.05] hover:border-gray-300 hover:shadow-md active:scale-95 focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:outline-none dark:border-gray-500 dark:bg-gray-600 dark:hover:border-gray-400 dark:hover:shadow-lg"
-                onClick={() => copy(icon.name)}
+      {isCategoryEmpty ? (
+        <div className="mt-16 flex flex-col items-center gap-2 text-center text-gray-400 dark:text-gray-500">
+          <svg
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth={1.5}
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            className="h-10 w-10 opacity-40"
+            aria-hidden="true"
+          >
+            <circle cx={12} cy={12} r={10} />
+            <path d="M8 12h8" />
+          </svg>
+          <p className="text-base font-medium">No icons yet</p>
+          <p className="text-sm">
+            {category === 'bridge'
+              ? 'Bridge icons are coming in v3.0'
+              : `${category.charAt(0).toUpperCase()}${category.slice(1)} icons are coming soon`}
+          </p>
+        </div>
+      ) : isSearchEmpty ? (
+        <div className="mt-16 flex flex-col items-center gap-2 text-center text-gray-400 dark:text-gray-500">
+          <svg
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth={1.5}
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            className="h-10 w-10 opacity-40"
+            aria-hidden="true"
+          >
+            <circle cx={11} cy={11} r={8} />
+            <path d="m21 21-4.35-4.35" />
+          </svg>
+          <p className="text-base font-medium">
+            No results for &ldquo;{keyword}&rdquo;
+          </p>
+          <p className="text-sm">Try a different search term</p>
+        </div>
+      ) : (
+        <div className="mt-6 grid grid-cols-[repeat(auto-fill,minmax(96px,1fr))] gap-x-3 gap-y-4">
+          {displayedIcons.map(icon => {
+            const isCopied = copiedName === icon.name;
+            return (
+              <div
+                key={icon.name}
+                className="relative flex flex-col items-center"
               >
-                <icon.component
-                  className={`text-4xl drop-shadow transition-all duration-150 dark:drop-shadow-[0_1px_1px_rgba(255,255,255,0.1)] ${
-                    isCopied ? 'scale-90 opacity-30' : ''
+                <button
+                  type="button"
+                  aria-label={`Copy ${icon.name}`}
+                  title={icon.name}
+                  className="group mx-auto flex aspect-square w-full cursor-pointer items-center justify-center rounded-lg border border-gray-200 bg-white shadow-sm transition-all duration-150 ease-out hover:scale-[1.05] hover:border-gray-300 hover:shadow-md active:scale-95 focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:outline-none dark:border-gray-500 dark:bg-gray-600 dark:hover:border-gray-400 dark:hover:shadow-lg"
+                  onClick={() => copy(icon.name)}
+                >
+                  <icon.component
+                    className={`text-4xl drop-shadow transition-all duration-150 dark:drop-shadow-[0_1px_1px_rgba(255,255,255,0.1)] ${
+                      isCopied ? 'scale-90 opacity-30' : ''
+                    }`}
+                  />
+                  {isCopied && (
+                    <svg
+                      viewBox="0 0 24 24"
+                      fill="none"
+                      stroke="currentColor"
+                      strokeWidth={3}
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                      className="absolute h-6 w-6 text-green-500 dark:text-green-400"
+                      aria-hidden="true"
+                    >
+                      <polyline points="20 6 9 17 4 12" />
+                    </svg>
+                  )}
+                </button>
+                <p
+                  title={icon.name}
+                  className={`mt-1 w-full text-balance text-center text-xs font-medium leading-tight transition-colors duration-150 ${
+                    isCopied ? 'text-green-600 dark:text-green-400' : ''
                   }`}
-                />
-                {isCopied && (
-                  <svg
-                    viewBox="0 0 24 24"
-                    fill="none"
-                    stroke="currentColor"
-                    strokeWidth={3}
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                    className="absolute h-6 w-6 text-green-500 dark:text-green-400"
-                    aria-hidden="true"
-                  >
-                    <polyline points="20 6 9 17 4 12" />
-                  </svg>
-                )}
-              </button>
-              <p
-                className={`mt-0.5 w-24 overflow-hidden text-ellipsis text-center text-xs font-medium transition-colors duration-150 ${
-                  isCopied ? 'text-green-600 dark:text-green-400' : ''
-                }`}
-              >
-                {isCopied ? 'Copied!' : icon.name}
-              </p>
-            </div>
-          );
-        })}
-      </div>
+                >
+                  {isCopied ? 'Copied!' : icon.name}
+                </p>
+              </div>
+            );
+          })}
+        </div>
+      )}
     </section>
   );
 }


### PR DESCRIPTION
## Summary

Four example app improvements bundled together:

- **CSS Grid (#260)**: Icon grid now uses `grid-cols-[repeat(auto-fill,minmax(96px,1fr))]` instead of `flex flex-wrap`. Cards scale with viewport width; no silent name truncation (icon names use `text-balance` and a `title` tooltip as fallback)
- **Variant toggle (#262)**: All / Colored / Mono segmented control above the search box. Composes with keyword search and category selection
- **Empty state (#261)**: Selecting an empty category (bridge) shows "No icons yet" with a contextual message. Searching with no matches shows "No results for '…'"
- **Footer (#263)**: Fixed footer at layout level with npm install command (click-to-copy), package version, MIT license, GitHub and npm links

## Related issue

Closes #260, Closes #261, Closes #262, Closes #263

## Checklist

- [x] Lint and typecheck passing
- [x] No `src/` changes — changeset not required