### PR TITLE
feat(example): display icon count per category in the category bar

### DIFF
--- a/example/src/components/sections/CategoryBar.tsx
+++ b/example/src/components/sections/CategoryBar.tsx
@@ -49,8 +49,8 @@ export default function CategoryBar() {
                   isActive
                     ? 'opacity-80'
                     : count === 0
-                      ? 'text-gray-300 dark:text-gray-600'
-                      : 'text-gray-400 dark:text-gray-400'
+                      ? 'text-gray-500 dark:text-gray-400'
+                      : 'text-gray-600 dark:text-gray-300'
                 }`}
               >
                 {count}


### PR DESCRIPTION
## Summary

- Each category pill now shows the icon count as a small number next to the label (e.g. `chain 45`, `wallet 32`)
- Zero-count categories get muted text color to visually distinguish them from populated ones
- Count reflects the total icons per category (variant-filtered counts can be layered on top when variant URL state is implemented)

## Related issue

Closes #266

## Checklist

- [x] TypeScript passes
- [x] Biome passes
- [x] Tests pass (530)
- [x] No breaking changes (example-only UI change)
- [x] No changeset needed (example/ changes only)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 新機能
* カテゴリバーに各カテゴリのアイテム数を表示するようになりました。アイテムが存在しない場合はグレーで表示され、アイテムがある場合または選択されているカテゴリでは異なるスタイルで強調表示されます。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->