### PR TITLE
feat(example): add keyboard shortcuts to focus search input

### DIFF
--- a/example/src/components/elements/SearchForm.tsx
+++ b/example/src/components/elements/SearchForm.tsx
@@ -32,7 +32,8 @@ export default function SearchForm({
       if (
         e.key === '/' &&
         !(e.target instanceof HTMLInputElement) &&
-        !(e.target instanceof HTMLTextAreaElement)
+        !(e.target instanceof HTMLTextAreaElement) &&
+        !(e.target as HTMLElement).isContentEditable
       ) {
         e.preventDefault();
         input.focus();
@@ -83,7 +84,7 @@ export default function SearchForm({
         <path d="m21 21-4.35-4.35" />
       </svg>
       {!keyword && (
-        <kbd className="pointer-events-none absolute right-3 rounded border border-gray-200 bg-gray-50 px-1.5 py-0.5 font-sans text-xs text-gray-400 opacity-70 peer-focus:opacity-0 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-500">
+        <kbd className="pointer-events-none absolute right-3 rounded border border-gray-200 bg-gray-50 px-1.5 py-0.5 font-sans text-xs text-gray-400 opacity-70 transition-opacity duration-100 peer-focus:opacity-0 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-500">
           /
         </kbd>
       )}


### PR DESCRIPTION
## Summary

- Press `/` when focus is outside any input to jump to the search field
- Press `Cmd+K` / `Ctrl+K` from anywhere to focus search (default browser behavior prevented)
- Press `Escape` to blur the search input
- A `/` keyboard hint badge appears on the right side of the search field when empty; it fades when focused and hides when typing starts

## Related issue

Closes #265

## Checklist

- [x] TypeScript passes
- [x] Biome passes
- [x] Tests pass (530)
- [x] No breaking changes (example-only UI change)
- [x] No changeset needed (example/ changes only)