### PR TITLE
feat(example): enable Next.js static export

### DIFF
--- a/example/next.config.ts
+++ b/example/next.config.ts
@@ -3,6 +3,7 @@ import type { NextConfig } from 'next';
 const nextConfig: NextConfig = {
   reactStrictMode: true,
   trailingSlash: true,
+  output: 'export',
 };
 
 export default nextConfig;


### PR DESCRIPTION
## Summary

- Add `output: 'export'` to `example/next.config.ts`
- `next build` now produces an `out/` directory of plain HTML/CSS/JS files
- All routes (`/`, `/404`) are statically prerendered — no server-side data fetching, API routes, or server actions exist
- Vercel deployment continues to work unchanged (Vercel handles static export natively)
- nuqs compatibility with static export confirmed (no issues)

## Related issue

Closes #275

## Checklist

- [x] `next build` succeeds and produces `out/`
- [x] All routes prerender as static (`○`)
- [x] Biome check passes
- [x] No breaking changes