### PR TITLE
chore: set displayName on IconContext for React DevTools

### DIFF
--- a/.changeset/iconcontext-displayname.md
+++ b/.changeset/iconcontext-displayname.md
@@ -1,0 +1,5 @@
+---
+"react-web3-icons": patch
+---
+
+Set `displayName` on `IconContext` for improved React DevTools label

--- a/src/utils/IconContext.tsx
+++ b/src/utils/IconContext.tsx
@@ -6,6 +6,7 @@ export type IconContextValue = Partial<Omit<IconProps, 'ref'>>;
 const EMPTY: IconContextValue = {};
 
 export const IconContext = createContext<IconContextValue>(EMPTY);
+IconContext.displayName = 'ReactWeb3Icons.IconContext';
 
 export function useIconContext<T extends IconProps>(props: T): T {
   const ctx = useContext(IconContext);


### PR DESCRIPTION
## Summary

Set `displayName` on `IconContext` so React DevTools shows `ReactWeb3Icons.IconContext` instead of the generic `Context` label.

## Related issue

Closes #349

## Checklist

- [x] One-line change with no behavioral impact
- [x] All tests pass
- [x] Changeset added (patch)