### PR TITLE
test: address review comments from PR #354

### DIFF
--- a/test/snapshot.test.tsx
+++ b/test/snapshot.test.tsx
@@ -28,7 +28,6 @@ const representatives: [string, ComponentType][] = [
   ['Bitcoin', Bitcoin],
   ['Arbitrum', Arbitrum],
   // coin (alias) — omitted: covered by chain originals
-  // devtool — no separate import needed, coverage via chain/exchange
   // dex
   ['Uniswap', Uniswap],
   ['PancakeSwap', PancakeSwap],
@@ -50,7 +49,7 @@ const representatives: [string, ComponentType][] = [
   ['CoinGecko', CoinGecko],
   // wallet
   ['MetaMask', MetaMask],
-  // bridge — appended to preserve snapshot IDs of existing entries
+  // bridge
   ['Wormhole', Wormhole],
   // defi
   ['Lido', Lido],

--- a/test/subpath-exports.test.ts
+++ b/test/subpath-exports.test.ts
@@ -114,5 +114,6 @@ describe('Category module exports', () => {
     expect(Object.keys(wallet)).toContain('ArgentMono');
     expect(Object.keys(wallet)).toContain('MetaMask');
     expect(Object.keys(wallet)).toContain('CoinbaseWallet');
+    expect(Object.keys(wallet)).toContain('CoinbaseWalletMono');
   });
 });


### PR DESCRIPTION
## Summary

Two minor test quality improvements in response to code review on #354 (already merged):

- Add `CoinbaseWalletMono` assertion to wallet subpath test — ensures both colored and Mono exports are verified, consistent with the approach used in other categories
- Remove stale comment in `snapshot.test.tsx` that said devtool coverage came from chain/exchange (Hardhat is now explicitly listed)
- Remove misleading comment about "preserve snapshot IDs" — vitest snapshots key by test name, not by position in the array

## Related issue

Related: #342

## Checklist

- [x] No changeset needed (test-only change)
- [x] All 546 tests pass