### PR TITLE
chore: add breaking changes section to pull request template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -19,7 +19,7 @@
 <!-- If this PR introduces a breaking change or deprecates an export, document it here. -->
 <!-- - Breaking: removed/renamed export `X` -->
 <!-- - Deprecated: `OldName` → `NewName` (removal planned for next major) -->
-<!-- Write N/A if not applicable -->
+<!-- write N/A if not applicable -->
 
 ## Checklist
 


### PR DESCRIPTION
## Summary

- Added a **Breaking changes / Deprecations** section to the PR template between Icon source verification and Checklist
- Section includes comment guidance for documenting removed/renamed exports and deprecations with a planned removal major

## Related issue

Closes #348

## Breaking changes / Deprecations

N/A

## Checklist

- [x] No `src/` changes — no changeset needed