### PR TITLE
chore(ci): auto-label PRs based on changed file paths

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,80 @@
+# Auto-labeler configuration for actions/labeler@v5
+# Labels are applied when a PR modifies files matching any listed glob pattern.
+
+# Icon categories
+icon:bridge:
+  - changed-files:
+    - any-glob-to-any-file: src/bridge/**
+
+icon:chain:
+  - changed-files:
+    - any-glob-to-any-file: src/chain/**
+
+icon:coin:
+  - changed-files:
+    - any-glob-to-any-file: src/coin/**
+
+icon:defi:
+  - changed-files:
+    - any-glob-to-any-file: src/defi/**
+
+icon:devtool:
+  - changed-files:
+    - any-glob-to-any-file: src/devtool/**
+
+icon:dex:
+  - changed-files:
+    - any-glob-to-any-file: src/dex/**
+
+icon:domain:
+  - changed-files:
+    - any-glob-to-any-file: src/domain/**
+
+icon:exchange:
+  - changed-files:
+    - any-glob-to-any-file: src/exchange/**
+
+icon:explorer:
+  - changed-files:
+    - any-glob-to-any-file: src/explorer/**
+
+icon:marketplace:
+  - changed-files:
+    - any-glob-to-any-file: src/marketplace/**
+
+icon:node:
+  - changed-files:
+    - any-glob-to-any-file: src/node/**
+
+icon:portfolio:
+  - changed-files:
+    - any-glob-to-any-file: src/portfolio/**
+
+icon:storage:
+  - changed-files:
+    - any-glob-to-any-file: src/storage/**
+
+icon:tracker:
+  - changed-files:
+    - any-glob-to-any-file: src/tracker/**
+
+icon:wallet:
+  - changed-files:
+    - any-glob-to-any-file: src/wallet/**
+
+# Other categories
+documentation:
+  - changed-files:
+    - any-glob-to-any-file: '**/*.md'
+    - any-glob-to-any-file: docs/**
+
+test:
+  - changed-files:
+    - any-glob-to-any-file: test/**
+    - any-glob-to-any-file: '**/*.test.*'
+    - any-glob-to-any-file: '**/*.spec.*'
+
+github_actions:
+  - changed-files:
+    - any-glob-to-any-file: .github/workflows/**
+    - any-glob-to-any-file: .github/actions/**

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,0 +1,19 @@
+name: Label
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - reopened
+      - synchronize
+
+jobs:
+  label:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - uses: actions/labeler@v5
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

- Added `.github/labeler.yml` mapping all 15 icon category `src/` directories to their corresponding `icon:*` labels
- Added `.github/workflows/labeler.yml` using `actions/labeler@v5` triggered on `pull_request_target` (open/reopen/synchronize)
- Also covers `documentation`, `test`, and `github_actions` labels
- Created missing icon category labels: `icon:exchange`, `icon:marketplace`, `icon:devtool`, `icon:explorer`, `icon:node`, `icon:storage`, `icon:domain`, `icon:portfolio`, `icon:tracker`

## Related issue

Closes #345

## Breaking changes / Deprecations

N/A

## Checklist

- [x] No `src/` changes — no changeset needed