### PR TITLE
chore: add bridge and defi to icon request template dropdown

### DIFF
--- a/.github/ISSUE_TEMPLATE/icon-request.yml
+++ b/.github/ISSUE_TEMPLATE/icon-request.yml
@@ -17,19 +17,21 @@ body:
       label: Target category
       description: Select the best matching category
       options:
+        - bridge
         - chain
         - coin
-        - wallet
+        - defi
+        - devtool
         - dex
+        - domain
         - exchange
         - explorer
-        - devtool
         - marketplace
-        - storage
-        - domain
         - node
         - portfolio
+        - storage
         - tracker
+        - wallet
         - other (please explain in additional context)
     validations:
       required: true


### PR DESCRIPTION
## Summary

- Add `bridge` and `defi` to the category dropdown in `.github/ISSUE_TEMPLATE/icon-request.yml`
- Sort all options alphabetically (was previously in an arbitrary order)

Both categories have existed since earlier releases but were missing from the template, forcing contributors to select `other` when requesting bridge or DeFi icons.

## Related issue

Closes #296

## Icon source verification (required for icon add/update PRs)

N/A

## Breaking changes / Deprecations

N/A

## Checklist

- [x] Lint passes (`pnpm run check`)
- [x] Tests pass (`pnpm test`)
- [x] Build succeeds (`pnpm run build`)
- [x] Changeset included (if `src/` changed): N/A — config-only change
- [x] Official icon source and usage context documented above (or N/A)
- [x] Default icon geometry/colors match official asset (or N/A)