### PR TITLE
docs(readme): add IconContext usage example

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,21 @@ The root import still works and includes all icons:
 import { Ethereum } from 'react-web3-icons';
 ```
 
+### IconContext
+
+Use `IconContext.Provider` to set default props for all icons in a subtree:
+
+```tsx
+import { IconContext } from 'react-web3-icons';
+
+<IconContext.Provider value={{ size: 32, className: 'my-icon' }}>
+  <Ethereum />
+  <Bitcoin />
+</IconContext.Provider>
+```
+
+Any prop that can be passed directly to an icon can be set via context (`size`, `className`, `style`, `fill`, etc.). Per-icon props always take precedence; `style` objects are merged rather than replaced.
+
 ## Icon Categories
 
 | Category | Description | Examples |


### PR DESCRIPTION
## Summary

- Add an `IconContext` subsection under the Usage section in the README
- Includes a code example showing `IconContext.Provider` with `size` and `className` defaults
- Documents that any icon prop can be set via context, per-icon props always win, and `style` objects are merged

## Related issue

Closes #299

## Icon source verification (required for icon add/update PRs)

N/A

## Breaking changes / Deprecations

N/A

## Checklist

- [x] Lint passes (`pnpm run check`)
- [x] Tests pass (`pnpm test`)
- [x] Build succeeds (`pnpm run build`)
- [x] Changeset included (if `src/` changed): N/A — docs-only change
- [x] Official icon source and usage context documented above (or N/A)
- [x] Default icon geometry/colors match official asset (or N/A)