### PR TITLE
test: add SVG quality checks (viewBox, style tags, px dimensions)

### DIFF
--- a/test/svg-quality.test.tsx
+++ b/test/svg-quality.test.tsx
@@ -4,9 +4,20 @@ import ReactDOM from 'react-dom/client';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 import * as icons from '../src';
 
-const entries = Object.entries(icons).filter(
-  ([name]) => name !== 'IconContext' && name !== 'DEPRECATED_ICON_NAMES',
-) as [string, ComponentType][];
+const forwardRefType = Symbol.for('react.forward_ref');
+const entries = Object.entries(icons).filter(([, value]) => {
+  if (typeof value === 'function') {
+    return true;
+  }
+  if (
+    typeof value === 'object' &&
+    value !== null &&
+    '$$typeof' in (value as object)
+  ) {
+    return (value as { $$typeof?: unknown }).$$typeof === forwardRefType;
+  }
+  return false;
+}) as [string, ComponentType][];
 
 describe('SVG quality checks', () => {
   describe.each(entries)('%s', (_name, Component) => {
@@ -26,6 +37,13 @@ describe('SVG quality checks', () => {
       root?.unmount();
       root = null;
       svg = null;
+    });
+
+    it('renders an SVG element', () => {
+      expect(
+        svg,
+        `${_name}: component did not render an <svg> element`,
+      ).not.toBeNull();
     });
 
     it('has a viewBox attribute', () => {
@@ -69,10 +87,14 @@ describe('SVG quality checks', () => {
       const width = svg?.getAttribute('width');
       const height = svg?.getAttribute('height');
       if (width) {
-        expect(width, `${_name}: hardcoded px width`).not.toMatch(/\d+px$/);
+        expect(width, `${_name}: hardcoded px width`).not.toMatch(
+          /[+-]?(?:\d+|\d*\.\d+)px$/i,
+        );
       }
       if (height) {
-        expect(height, `${_name}: hardcoded px height`).not.toMatch(/\d+px$/);
+        expect(height, `${_name}: hardcoded px height`).not.toMatch(
+          /[+-]?(?:\d+|\d*\.\d+)px$/i,
+        );
       }
     });
   });


### PR DESCRIPTION
## Summary

- Add `test/svg-quality.test.tsx` with automated checks that run against every exported icon component (1168 tests)
- **viewBox**: every icon must have a `viewBox` attribute
- **No `<style>` tags**: SVG content must use inline attributes/props rather than embedded stylesheets
- **No hardcoded static IDs**: internal IDs (gradients, masks, clip paths) must use React's `useId()` via `createIcon`'s `_id` parameter to avoid DOM collisions when an icon is used multiple times on a page
- **No hardcoded `px` dimensions**: the SVG root `width`/`height` must not use pixel values (they should use `size`/`em`/unitless)

The static-ID check uses `/^_r_\w+_|^:r\w+:/` to recognize both JSDOM (`_r_N_`) and production React (`:rN:`) `useId()` formats, correctly distinguishing them from icons that compose the dynamic `_id` with a descriptor suffix (e.g. `` id={`${_id}-gradient`} ``).

All 1168 tests pass.

## Related issue

Closes #326

## Icon source verification (required for icon add/update PRs)

N/A

## Breaking changes / Deprecations

N/A

## Checklist

- [x] Lint passes (`pnpm run check`)
- [x] Tests pass (`pnpm test`)
- [x] Build succeeds (`pnpm run build`)
- [x] Changeset included (if `src/` changed): N/A — test-only change
- [x] Official icon source and usage context documented above (or N/A)
- [x] Default icon geometry/colors match official asset (or N/A)