### PR TITLE
docs(readme): document React Server Components compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,12 +154,22 @@ export function MyComponent() {
 }
 ```
 
-Alternatively, create a small client-only re-export wrapper:
+Alternatively, create a small client-only re-export wrapper and import icons from it in your Client Components:
 
 ```tsx
 // app/icons.tsx — must be a Client Component
 'use client';
 export { Ethereum, Bitcoin } from 'react-web3-icons';
+```
+
+```tsx
+// app/my-component.tsx — Client Component that renders icons
+'use client';
+import { Ethereum } from './icons';
+
+export function MyComponent() {
+  return <Ethereum />;
+}
 ```
 
 ## Icon Categories


### PR DESCRIPTION
## Summary

- Add "React Server Components (RSC)" subsection under Usage in the README
- Documents that icons cannot be used in RSC directly (they use `useId`, `useContext`, `forwardRef`)
- Provides the recommended workaround: add `'use client'` to a re-export file or the component file that renders icons

Decision on adding `'use client'` directly to library source files: deferred — it would work but adds a build-time constraint. The current workaround is a single line and easy for Next.js users to apply.

## Related issue

Closes #311

## Icon source verification (required for icon add/update PRs)

N/A

## Breaking changes / Deprecations

N/A

## Checklist

- [x] Lint passes (`pnpm run check`)
- [x] Tests pass (`pnpm test`)
- [x] Build succeeds (`pnpm run build`)
- [x] Changeset included (if `src/` changed): N/A — docs-only change
- [x] Official icon source and usage context documented above (or N/A)
- [x] Default icon geometry/colors match official asset (or N/A)