### PR TITLE
chore(ci): add example app build verification

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -62,3 +62,30 @@ jobs:
 
       - name: Build
         run: pnpm run build
+
+  build-example:
+    name: Build example app
+    runs-on: ubuntu-latest
+    needs: build
+
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v6
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Use Node 24.x
+        uses: actions/setup-node@v6
+        with:
+          node-version: '24.x'
+          cache: pnpm
+
+      - name: Install deps
+        run: pnpm install --frozen-lockfile
+
+      - name: Build library
+        run: pnpm run build
+
+      - name: Build example app
+        run: pnpm --filter react-web3-icons-example run build


### PR DESCRIPTION
## Summary

- Add a `build-example` CI job that runs `next build` on the example app after the library builds pass
- Runs on Node 24.x only to avoid tripling CI time
- Waits for the `build` matrix job to complete (`needs: build`) before running
- Catches TypeScript errors, import failures, and Next.js API incompatibilities in the example app before merge

## Related issue

Closes #308

## Icon source verification (required for icon add/update PRs)

N/A

## Breaking changes / Deprecations

N/A

## Checklist

- [x] Lint passes (`pnpm run check`)
- [x] Tests pass (`pnpm test`)
- [x] Build succeeds (`pnpm run build`)
- [x] Changeset included (if `src/` changed): N/A — CI config only
- [x] Official icon source and usage context documented above (or N/A)
- [x] Default icon geometry/colors match official asset (or N/A)