### PR TITLE
feat(example): copy import statement on icon click

### DIFF
--- a/example/src/components/elements/IconCard.tsx
+++ b/example/src/components/elements/IconCard.tsx
@@ -1,4 +1,5 @@
 import type { ComponentType } from 'react';
+import { buildImportStatement } from '../../hooks/useCopy';
 
 interface Props {
   name: string;
@@ -20,7 +21,7 @@ export default function IconCard({
       <button
         type="button"
         aria-label={`Copy import for ${name}`}
-        title={`import { ${name} } from 'react-web3-icons'`}
+        title={buildImportStatement(name)}
         className={`group mx-auto flex aspect-square w-full cursor-pointer items-center justify-center rounded-lg border shadow-sm transition-all duration-150 ease-out hover:scale-[1.05] hover:shadow-md active:scale-95 focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:outline-none ${
           previewDark
             ? 'border-gray-700 bg-gray-900 text-white hover:border-gray-600'

--- a/example/src/hooks/useCopy.ts
+++ b/example/src/hooks/useCopy.ts
@@ -2,6 +2,10 @@
 
 import { useEffect, useRef, useState } from 'react';
 
+export function buildImportStatement(name: string): string {
+  return `import { ${name} } from 'react-web3-icons';`;
+}
+
 export function useCopy() {
   const [copiedName, setCopiedName] = useState<string | null>(null);
   const [copyStatus, setCopyStatus] = useState('');
@@ -16,7 +20,7 @@ export function useCopy() {
   }, []);
 
   const copy = (name: string) => {
-    const text = `import { ${name} } from 'react-web3-icons';`;
+    const text = buildImportStatement(name);
     navigator.clipboard
       .writeText(text)
       .then(() => {


### PR DESCRIPTION
## Summary

- Clicking an icon card now copies a ready-to-paste import statement (e.g. `import { Ethereum } from 'react-web3-icons';`) instead of just the component name
- Updated `aria-label` from "Copy Ethereum" to "Copy import for Ethereum"  
- Updated `title` tooltip to show the full import statement
- Status message updated to "Copied import for Ethereum"

The component name (`copiedName`) is still tracked as-is for UI state (highlight / "Copied!" label), only the clipboard content changes.

## Related issue

Closes #300

## Checklist

- [x] No `src/` changes — changeset not required
- [x] No breaking changes
- [x] Example builds: `pnpm --filter react-web3-icons-example build` passes