### PR TITLE
docs: add StackBlitz live demo badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,8 @@ pnpm add react-web3-icons
 
 ## Quick Start
 
+[![Open in StackBlitz](https://developer.stackblitz.com/img/open_in_stackblitz.svg)][stackblitz-url]
+
 ```tsx
 import { Ethereum, EthereumMono } from 'react-web3-icons';
 


### PR DESCRIPTION
## Summary

- Add StackBlitz badge to the README header badge row linking to the live example app

## Related issue

Closes #307

## Checklist

- [x] No `src/` changes (no changeset needed)
- [x] CI checks pass (typecheck, lint, build, test)