### PR TITLE
docs: add bridge and defi categories to README and CONTRIBUTING

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,6 +35,8 @@ src/
   chain/        # L1/L2 blockchain icons (Ethereum, Arbitrum, etc.)
   coin/         # Cryptocurrency icons (Bitcoin, Doge, etc.)
   dex/          # DEX icons (Uniswap, SushiSwap, etc.)
+  defi/         # DeFi protocol icons (Aave, EigenLayer, Lido)
+  bridge/       # Cross-chain bridge icons (Across, LayerZero, etc.)
   wallet/       # Wallet icons (MetaMask, Phantom, etc.)
   marketplace/  # NFT marketplace icons
   storage/      # Decentralized storage icons

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ A comprehensive React SVG icon library for Web3 — blockchains, wallets, DEXs, 
 
 ## Features
 
-- 130+ icons across 13 categories
+- 200+ icons across 15 categories
 - Colored and monochrome variants for every icon
 - Tree-shakeable — only import what you use (`sideEffects: false`)
 - Scales with font size (`1em` default)
@@ -132,6 +132,8 @@ import { Ethereum } from 'react-web3-icons';
 | `coin` | Cryptocurrencies & tokens | Bitcoin, Doge, Usdt, Usdc |
 | `wallet` | Wallet apps | MetaMask, PhantomWallet, RainbowWallet |
 | `dex` | Decentralized exchanges | Uniswap, PancakeSwap, Dydx |
+| `defi` | DeFi protocols | Aave, EigenLayer, Lido |
+| `bridge` | Cross-chain bridge protocols | Across, LayerZero, Stargate, Wormhole |
 | `exchange` | Centralized exchanges | Binance, Coinbase, Kraken |
 | `marketplace` | NFT marketplaces | OpenSea, MagicEden, LooksRare |
 | `devtool` | Developer tools | Hardhat, Truffle, Web3Js |


### PR DESCRIPTION
## Summary

- Update icon count from "130+" to "200+" (actual: 267 exports)
- Update category count from 13 to 15
- Add `bridge` and `defi` rows to the Icon Categories table in README
- Add `bridge/` and `defi/` to the Project Structure in CONTRIBUTING.md

## Related issue

Closes #294

## Checklist

- [x] No source changes — docs only, no changeset needed
- [x] All 15 categories now appear in both README and CONTRIBUTING
- [x] CI (typecheck / lint / build / test) passes