### PR TITLE
feat(example): add SVG download button to icon cards

### DIFF
--- a/example/src/components/elements/IconCard.tsx
+++ b/example/src/components/elements/IconCard.tsx
@@ -1,4 +1,5 @@
 import type { ComponentType } from 'react';
+import { useRef } from 'react';
 import { buildImportStatement } from '../../hooks/useCopy';
 
 interface Props {
@@ -9,6 +10,22 @@ interface Props {
   previewDark?: boolean;
 }
 
+function downloadSvg(name: string, container: HTMLElement | null) {
+  const svg = container?.querySelector('svg');
+  if (!svg) return;
+  const serializer = new XMLSerializer();
+  const svgStr =
+    '<?xml version="1.0" encoding="UTF-8"?>\n' +
+    serializer.serializeToString(svg);
+  const blob = new Blob([svgStr], { type: 'image/svg+xml' });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement('a');
+  a.href = url;
+  a.download = `${name}.svg`;
+  a.click();
+  URL.revokeObjectURL(url);
+}
+
 export default function IconCard({
   name,
   component: Icon,
@@ -16,8 +33,13 @@ export default function IconCard({
   onCopy,
   previewDark = false,
 }: Props) {
+  const containerRef = useRef<HTMLDivElement>(null);
+
   return (
-    <div className="relative flex flex-col items-center">
+    <div
+      ref={containerRef}
+      className="group relative flex flex-col items-center"
+    >
       <button
         type="button"
         aria-label={`Copy import for ${name}`}
@@ -48,6 +70,29 @@ export default function IconCard({
             <polyline points="20 6 9 17 4 12" />
           </svg>
         )}
+      </button>
+      <button
+        type="button"
+        aria-label={`Download ${name} SVG`}
+        title={`Download ${name}.svg`}
+        onClick={e => {
+          e.stopPropagation();
+          downloadSvg(name, containerRef.current);
+        }}
+        className="absolute top-1 right-1 z-10 rounded p-0.5 text-gray-400 opacity-0 transition-opacity duration-100 hover:text-gray-700 group-hover:opacity-100 focus-visible:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 dark:text-gray-500 dark:hover:text-gray-200"
+      >
+        <svg
+          viewBox="0 0 16 16"
+          className="h-3.5 w-3.5"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth={1.5}
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          aria-hidden="true"
+        >
+          <path d="M2.5 13h11M8 2v8m0 0-3-3m3 3 3-3" />
+        </svg>
       </button>
       <p
         title={name}


### PR DESCRIPTION
## Summary

- Adds a small download button to each icon card (visible on hover, keyboard-accessible via focus)
- Clicking downloads the rendered SVG as `{IconName}.svg` using the browser-native `XMLSerializer` API
- No extra dependencies
- Stop-propagation prevents the copy action from triggering simultaneously

## Details

The button is positioned in the top-right corner of the card and uses opacity-0 / group-hover:opacity-100 to stay hidden until the card is hovered. The SVG is obtained by querying the card container for its `<svg>` element and serialized including the XML declaration.

## Related issue

Closes #302

## Checklist

- [x] Example app only — no changeset needed
- [x] No new dependencies
- [x] Download action and copy action do not conflict (`stopPropagation` on click)
- [x] Keyboard accessible (focus-visible ring)
- [x] Lint, typecheck, test, build all pass