### PR TITLE
feat(wallet): add Ledger and LedgerMono icon variants

### DIFF
--- a/.changeset/ledger-icon.md
+++ b/.changeset/ledger-icon.md
@@ -1,0 +1,5 @@
+---
+"react-web3-icons": minor
+---
+
+feat(wallet): add Ledger and LedgerMono icon variants

--- a/src/wallet/Ledger.tsx
+++ b/src/wallet/Ledger.tsx
@@ -1,0 +1,19 @@
+import { createIcon } from '../utils';
+
+const ledgerContent = () => (
+  <path d="M0.715088 17.1853V24H11.0853V22.4887H2.22605V17.1853H0.715088ZM26.7739 17.1853V22.4887H17.9147V23.9996H28.2849V17.1853H26.7739ZM11.1003 6.81473V17.1849H17.9147V15.822H12.6113V6.81473H11.1003ZM0.715088 0V6.81473H2.22605V1.51096H11.0853V0H0.715088ZM17.9147 0V1.51096H26.7739V6.81473H28.2849V0H17.9147Z" />
+);
+
+export const Ledger = createIcon(
+  'Ledger',
+  '0 0 29 24',
+  ledgerContent,
+  '#000000',
+);
+
+export const LedgerMono = createIcon(
+  'LedgerMono',
+  '0 0 29 24',
+  ledgerContent,
+  'currentColor',
+);

--- a/src/wallet/index.ts
+++ b/src/wallet/index.ts
@@ -2,6 +2,7 @@ export * from './Argent';
 export * from './CoinbaseWallet';
 export * from './DaedalusWallet';
 export * from './GnosisSafe';
+export * from './Ledger';
 export * from './MetaMask';
 export * from './NamiWallet';
 export * from './PhantomWallet';


### PR DESCRIPTION
## Summary

- Add `Ledger` component using the official bracket mark from `LedgerHQ/ledger-live` (`libs/ui/packages/icons/src/svg-legacy/medium/ledger-logo.svg`)
- Add `LedgerMono` variant using `currentColor` for CSS theming
- Mark-only design (no background), consistent with other wallet icons
- Brand color: `#000000` (Ledger black)
- ViewBox: `0 0 29 24`

## Related issue

Closes #182

## Checklist

- [x] `pnpm run check` passes
- [x] `pnpm run typecheck` passes
- [x] `pnpm test` passes
- [x] Changeset added

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * Ledgerウォレット用アイコンを追加しました。カラー版とモノクロ版の2つのバリエーションが利用可能です。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->