### PR TITLE
feat(wallet): add Trezor and TrezorMono icon variants

### DIFF
--- a/.changeset/trezor-icon.md
+++ b/.changeset/trezor-icon.md
@@ -1,0 +1,5 @@
+---
+"react-web3-icons": minor
+---
+
+feat(wallet): add Trezor and TrezorMono icon variants

--- a/src/wallet/Trezor.tsx
+++ b/src/wallet/Trezor.tsx
@@ -1,0 +1,19 @@
+import { createIcon } from '../utils';
+
+const trezorContent = () => (
+  <path d="M150.66 59.407C150.66 26.947 122.488 0 88.191 0S25.722 26.947 25.722 59.407v18.985H0v136.575L88.191 256l88.192-41.033V79.005H150.66zm-93.09 0c0-15.311 13.473-27.56 30.621-27.56 17.149 0 30.622 12.249 30.622 27.56v18.985H57.57zm83.291 133.512-52.67 24.497-52.67-24.497v-82.067h105.34z" />
+);
+
+export const Trezor = createIcon(
+  'Trezor',
+  '0 0 177 256',
+  trezorContent,
+  '#000000',
+);
+
+export const TrezorMono = createIcon(
+  'TrezorMono',
+  '0 0 177 256',
+  trezorContent,
+  'currentColor',
+);

--- a/src/wallet/index.ts
+++ b/src/wallet/index.ts
@@ -11,6 +11,7 @@ export * from './PhantomWallet';
 export * from './PolkadotJs';
 export * from './RainbowWallet';
 export * from './Safe';
+export * from './Trezor';
 export * from './TrustWallet';
 export * from './WalletConnect';
 export * from './YoroiWallet';


### PR DESCRIPTION
## Summary

- Add `Trezor` component using the official T-lock mark from `trezor/trezor-suite` (`packages/product-components/src/images/logos/trezor_logo_symbol.svg`)
- Add `TrezorMono` variant using `currentColor` for CSS theming
- Mark-only design (no background), single path
- Brand color: `#000000` (Trezor black)
- ViewBox: `0 0 177 256`

## Related issue

Closes #187

## Checklist

- [x] `pnpm run check` passes
- [x] `pnpm run typecheck` passes
- [x] `pnpm test` passes
- [x] `pnpm run build` passes
- [x] Changeset added