### PR TITLE
feat(defi): add Pendle, MakerDao, and RocketPool icon variants

### DIFF
--- a/.changeset/defi-icons-pendle-makerdao-rocketpool.md
+++ b/.changeset/defi-icons-pendle-makerdao-rocketpool.md
@@ -1,0 +1,5 @@
+---
+"react-web3-icons": minor
+---
+
+feat(defi): add Pendle, MakerDao, and RocketPool icon variants

--- a/src/defi/MakerDao.tsx
+++ b/src/defi/MakerDao.tsx
@@ -1,0 +1,36 @@
+import { createIcon } from '../utils';
+
+// Paths sourced from @web3icons/react (MIT)
+const mkrPath =
+  'M3.224 6.66a.45.45 0 0 1 .448-.001l7.199 4.095a.45.45 0 0 1 .228.39v5.806a.45.45 0 1 1-.9 0v-5.544L3.9 7.824v9.126a.45.45 0 0 1-.9 0v-9.9a.45.45 0 0 1 .224-.39m17.552 0a.45.45 0 0 0-.449-.001l-7.198 4.095a.45.45 0 0 0-.228.39v5.806a.45.45 0 0 0 .9 0v-5.544L20.1 7.824v9.126a.45.45 0 0 0 .9 0v-9.9a.45.45 0 0 0-.224-.39';
+
+export const MakerDao = createIcon(
+  'MakerDao',
+  '0 0 24 24',
+  _id => (
+    <>
+      <defs>
+        <linearGradient
+          id={`${_id}-mkr-a`}
+          x1="3"
+          x2="21"
+          y1="12"
+          y2="12"
+          gradientUnits="userSpaceOnUse"
+        >
+          <stop stopColor="#1BC4A3" />
+          <stop offset="1" stopColor="#586979" />
+        </linearGradient>
+      </defs>
+      <path fill={`url(#${_id}-mkr-a)`} d={mkrPath} />
+    </>
+  ),
+  'none',
+);
+
+export const MakerDaoMono = createIcon(
+  'MakerDaoMono',
+  '0 0 24 24',
+  () => <path d={mkrPath} />,
+  'currentColor',
+);

--- a/src/defi/Pendle.tsx
+++ b/src/defi/Pendle.tsx
@@ -1,0 +1,38 @@
+import { createIcon } from '../utils';
+
+// Paths sourced from @web3icons/react (MIT)
+const pendleMonoContent = () => (
+  <>
+    <path d="M8.76 21a3.961 3.961 0 1 0 .001-7.922 3.961 3.961 0 0 0 0 7.922" />
+    <path d="M8.326 4.007v10.017h.883V3.56q-.459.194-.883.446" />
+  </>
+);
+
+export const Pendle = createIcon(
+  'Pendle',
+  '0 0 24 24',
+  () => (
+    <>
+      <path
+        fill="#fff"
+        d="M19.2 10.2a7.2 7.2 0 1 1-14.4 0 7.2 7.2 0 0 1 14.4 0"
+      />
+      <path
+        fill="#152E51"
+        d="M8.76 21a3.961 3.961 0 1 0 .001-7.922 3.961 3.961 0 0 0 0 7.922"
+      />
+      <path
+        fill="#152E51"
+        d="M8.326 4.007v10.017h.883V3.56q-.459.194-.883.446"
+      />
+    </>
+  ),
+  'none',
+);
+
+export const PendleMono = createIcon(
+  'PendleMono',
+  '0 0 24 24',
+  pendleMonoContent,
+  'currentColor',
+);

--- a/src/defi/RocketPool.tsx
+++ b/src/defi/RocketPool.tsx
@@ -1,0 +1,71 @@
+import { createIcon } from '../utils';
+
+// Paths sourced from @web3icons/react (MIT)
+const rocketPoolMonoContent = () => (
+  <>
+    <path
+      fillRule="evenodd"
+      d="m9.658 11.169-.864 1.034 1.214.455c.017.459.127.65.18.689l-.463.427.463.473.455-.473c.252.093.523.126.79.096l.427 1.241 1.07-.974.268-1.192c2.473-2.249 2.75-4.043 2.58-4.66-2.19-.156-4.15 1.646-4.855 2.567zm.052 3.512-3.669 3.385-.387-.42 3.669-3.385zm-1.176.079-3.01 2.752-.387-.422 3.011-2.753zm1.088 1.053-3.037 2.792-.386-.421 3.036-2.791zm3.277-4.075a.707.707 0 1 0 0-1.414.707.707 0 0 0 0 1.414"
+      clipRule="evenodd"
+    />
+    <path
+      fillRule="evenodd"
+      d="M12 21a9 9 0 1 0 0-18 9 9 0 0 0 0 18m0-.53A8.47 8.47 0 0 0 20.47 12 8.47 8.47 0 0 0 12 3.53 8.47 8.47 0 0 0 3.53 12 8.47 8.47 0 0 0 12 20.47"
+      clipRule="evenodd"
+    />
+  </>
+);
+
+export const RocketPool = createIcon(
+  'RocketPool',
+  '0 0 24 24',
+  _id => (
+    <>
+      <defs>
+        <linearGradient
+          id={`${_id}-rpl-a`}
+          x1="4.451"
+          x2="21"
+          y1="18.034"
+          y2="5.848"
+          gradientUnits="userSpaceOnUse"
+        >
+          <stop stopColor="#FB9533" />
+          <stop offset=".261" stopColor="#FEBA67" />
+          <stop offset=".747" stopColor="#FF9976" />
+          <stop offset="1" stopColor="#FF6350" />
+        </linearGradient>
+      </defs>
+      <path
+        fill={`url(#${_id}-rpl-a)`}
+        d="M12 20.34a8.399 8.399 0 1 0 0-16.797 8.399 8.399 0 0 0 0 16.797"
+      />
+      <path
+        fill="#FF7534"
+        fillRule="evenodd"
+        d="M12 20.459A8.457 8.457 0 0 0 20.458 12 8.458 8.458 0 1 0 12 20.459m0-.517A7.941 7.941 0 1 0 12 4.06a7.941 7.941 0 0 0 0 15.882"
+        clipRule="evenodd"
+      />
+      <path
+        fill="#FFD58D"
+        fillRule="evenodd"
+        d="M12 21a9 9 0 1 0 0-18 9 9 0 0 0 0 18m0-.53A8.47 8.47 0 0 0 20.47 12 8.47 8.47 0 0 0 12 3.53 8.47 8.47 0 0 0 3.53 12 8.47 8.47 0 0 0 12 20.47"
+        clipRule="evenodd"
+      />
+      <path
+        fill="#fff"
+        fillRule="evenodd"
+        d="m9.658 11.169-.864 1.034 1.214.455c.017.459.127.65.18.689l-.463.427.463.473.455-.473c.252.093.523.126.79.096l.427 1.241 1.07-.974.268-1.192c2.473-2.249 2.75-4.043 2.58-4.66-2.19-.156-4.15 1.646-4.855 2.567zm.052 3.512-3.669 3.385-.387-.42 3.669-3.385zm-1.176.079-3.01 2.752-.387-.422 3.011-2.753zm1.088 1.053-3.037 2.792-.386-.421 3.036-2.791zm3.277-4.075a.707.707 0 1 0 0-1.414.707.707 0 0 0 0 1.414"
+        clipRule="evenodd"
+      />
+    </>
+  ),
+  'none',
+);
+
+export const RocketPoolMono = createIcon(
+  'RocketPoolMono',
+  '0 0 24 24',
+  rocketPoolMonoContent,
+  'currentColor',
+);

--- a/src/defi/index.ts
+++ b/src/defi/index.ts
@@ -3,4 +3,7 @@ export * from './Balancer';
 export * from './Compound';
 export * from './EigenLayer';
 export * from './Lido';
+export * from './MakerDao';
+export * from './Pendle';
+export * from './RocketPool';
 export * from './Yearn';


### PR DESCRIPTION
## Summary

- Add `Pendle` / `PendleMono` icons (dark navy `#152E51`, white background circle)
- Add `MakerDao` / `MakerDaoMono` icons (teal-to-gray gradient `#1BC4A3 → #586979`)
- Add `RocketPool` / `RocketPoolMono` icons (orange gradient circle with rocket-key motif)

All SVG paths sourced from @web3icons/react (MIT licensed).

Note: Coin re-exports for PENDLE (#175) and MKR (#172) will follow in a separate coin batch PR after this is merged, to avoid conflicts with the open coin PR #409.

## Related issue

Closes #200, #316, #317

## Checklist

- [x] `pnpm run check` passes
- [x] `pnpm run typecheck` passes
- [x] `pnpm test` passes (2428 tests)
- [x] `pnpm run build` passes
- [x] `pnpm run size` within limits (defi: 3.62 kB / 5 kB)
- [x] Changeset included