### PR TITLE
feat(dex): add Hyperliquid icon

### DIFF
--- a/.changeset/dex-hyperliquid.md
+++ b/.changeset/dex-hyperliquid.md
@@ -1,0 +1,5 @@
+---
+"react-web3-icons": patch
+---
+
+feat(dex): add Hyperliquid icon

--- a/src/dex/Hyperliquid.tsx
+++ b/src/dex/Hyperliquid.tsx
@@ -1,0 +1,22 @@
+import { createIcon } from '../utils';
+
+// Paths sourced from @web3icons/react (MIT) — ExchangeHyperliquid SVG
+
+const hyperliquidPath =
+  'M21 11.937a9.4 9.4 0 0 1-.901 4.112c-.867 1.863-2.947 3.387-4.846 1.765-1.55-1.322-1.837-4.005-4.157-4.398-3.07-.361-3.145 3.092-5.15 3.482-2.236.44-2.978-3.206-2.945-4.862s.487-3.984 2.43-3.984c2.236 0 2.386 3.283 5.224 3.105 2.81-.186 2.86-3.602 4.696-5.064 1.585-1.264 3.448-.337 4.381 1.184.865 1.406 1.245 3.057 1.265 4.66z';
+
+const hyperliquidContent = () => <path d={hyperliquidPath} />;
+
+export const Hyperliquid = createIcon(
+  'Hyperliquid',
+  '0 0 24 24',
+  hyperliquidContent,
+  '#50D2C1',
+);
+
+export const HyperliquidMono = createIcon(
+  'HyperliquidMono',
+  '0 0 24 24',
+  hyperliquidContent,
+  'currentColor',
+);

--- a/src/dex/index.ts
+++ b/src/dex/index.ts
@@ -1,4 +1,5 @@
 export * from './Dydx';
+export * from './Hyperliquid';
 export * from './Jupiter';
 export * from './Oneinch';
 export * from './PancakeSwap';


### PR DESCRIPTION
## Summary

- Add `Hyperliquid` and `HyperliquidMono` icons to the `dex` category
- SVG sourced from @web3icons/react (MIT) ExchangeHyperliquid SVG
- Single-path icon with `#50D2C1` brand color; mono uses `currentColor`
- Shared path content function used for both variants

## Related issue

Closes #196

## Checklist

- [x] `pnpm run check` passed
- [x] `pnpm run typecheck` passed
- [x] `pnpm test` passed
- [x] `pnpm run build` passed
- [x] `pnpm run size` passed (dex: 7.49 kB / 10 kB)
- [x] Changeset included
- [x] No breaking changes