### PR TITLE
feat(devtool): add Privy icon variants

### DIFF
--- a/.changeset/devtool-privy.md
+++ b/.changeset/devtool-privy.md
@@ -1,0 +1,5 @@
+---
+"react-web3-icons": minor
+---
+
+feat(devtool): add Privy icon variants

--- a/src/devtool/Privy.tsx
+++ b/src/devtool/Privy.tsx
@@ -1,0 +1,24 @@
+import { createIcon } from '../utils';
+
+// Paths sourced from privy-io/examples (MIT) — Privy logomark (circle + shadow ellipse)
+
+const privyContent = () => (
+  <>
+    <path d="M194.443 283.398C231.716 283.398 261.943 253.172 261.943 215.898C261.943 178.625 231.716 148.398 194.443 148.398C157.169 148.398 126.943 178.625 126.943 215.898C126.943 253.172 157.169 283.398 194.443 283.398Z" />
+    <path d="M194.442 322.642C219.916 322.642 240.571 318.295 240.571 312.963C240.571 307.63 219.93 303.283 194.442 303.283C168.954 303.283 148.312 307.63 148.312 312.963C148.312 318.295 168.954 322.642 194.442 322.642Z" />
+  </>
+);
+
+export const Privy = createIcon(
+  'Privy',
+  '126 148 136 175',
+  privyContent,
+  '#5B4FFF',
+);
+
+export const PrivyMono = createIcon(
+  'PrivyMono',
+  '126 148 136 175',
+  privyContent,
+  'currentColor',
+);

--- a/src/devtool/index.ts
+++ b/src/devtool/index.ts
@@ -7,6 +7,7 @@ export * from './Ganache';
 export * from './Hardhat';
 export * from './Moralis';
 export * from './OpenZeppelin';
+export * from './Privy';
 export * from './Remix';
 export * from './Solidity';
 export * from './Tally';


### PR DESCRIPTION
## Summary

- Add `Privy` and `PrivyMono` icon components to the `devtool` category
- SVG paths sourced from `privy-io/examples` repository (MIT license) — the canonical Privy logomark: a filled circle body + small shadow ellipse below
- `Privy` uses brand purple `#5B4FFF`; `PrivyMono` uses `currentColor`
- viewBox `126 148 136 175` preserves the original coordinate space (non-zero origin, same approach as Tally)

## Related issue

Closes #344

## Checklist

- [x] `pnpm run check` — no issues
- [x] `pnpm run typecheck` — no issues
- [x] `pnpm test` — 2643 tests passed
- [x] `pnpm run build` — success
- [x] `pnpm run size` — devtool: 10.16 kB / 20 kB limit
- [x] Changeset added
- [ ] Breaking changes: none

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * Privy アイコンの新しいバリエーションを追加しました。標準版（#5B4FFF カラー）とモノクロ版（currentColor）の2種類がご利用いただけます。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->