### PR TITLE
fix(devtool): ChainlinkMono mask works correctly with any currentColor

### DIFF
--- a/.changeset/fix-chainlink-mono-mask.md
+++ b/.changeset/fix-chainlink-mono-mask.md
@@ -1,0 +1,7 @@
+---
+"react-web3-icons": patch
+---
+
+fix(devtool): ChainlinkMono mask cutout now works with any currentColor
+
+The `<mask>` element was placed outside `<defs>` (non-conformant SVG) and the inner hexagon cutout path had no explicit `fill`, causing it to inherit `currentColor`. When `currentColor` was white or light, the mask failed to cut out the center, rendering a solid hexagon instead of a ring. Both issues are now fixed: mask moved into `<defs>`, cutout path uses explicit `fill="#000"`.

--- a/src/devtool/Chainlink.tsx
+++ b/src/devtool/Chainlink.tsx
@@ -18,13 +18,17 @@ export const ChainlinkMono = createIcon(
   '0 0 37.8 43.6',
   _id => (
     <>
-      <mask id={`${_id}-chl-a`}>
-        <rect width="100%" height="100%" fill="#fff" />
-        <path d="M8 28.1V15.5l10.9-6.3 10.9 6.3v12.6l-10.9 6.3L8 28.1z" />
-      </mask>
+      <defs>
+        <mask id={`${_id}-chl-a`}>
+          <rect width="100%" height="100%" fill="#fff" />
+          <path
+            d="M8 28.1V15.5l10.9-6.3 10.9 6.3v12.6l-10.9 6.3L8 28.1z"
+            fill="#000"
+          />
+        </mask>
+      </defs>
       <path
         d="M18.9 0l-4 2.3L4 8.6l-4 2.3V32.7L4 35l11 6.3 4 2.3 4-2.3L33.8 35l4-2.3V10.9l-4-2.3-10.9-6.3-4-2.3z"
-        fill="currentColor"
         mask={`url(#${_id}-chl-a)`}
       />
     </>


### PR DESCRIPTION
## Summary

Fixed two issues in `ChainlinkMono` (`src/devtool/Chainlink.tsx`):

1. **`<mask>` moved into `<defs>`** — was placed directly in the render tree, which is non-conformant SVG
2. **Cutout path now has explicit `fill="#000"`** — previously inherited `currentColor`, causing the mask to fail when the icon was used with a white or light color (rendered as solid hexagon instead of ring)

**TrustWallet note:** `TrustWalletSquareMono` / `TrustWalletCircleMono` were also investigated as part of #468. Their `stroke="black"` approach is intentional — the colored variant is stroke-only (`fill="none"`), so the stroke-based cutout faithfully mirrors the original design. No change made.

## Related issue

Closes #468

## Checklist

- [x] `pnpm run check` passes
- [x] `pnpm run typecheck` passes
- [x] `pnpm test` passes (2898 tests)
- [x] `pnpm run build` passes
- [x] Changeset included