### PR TITLE
fix(chain): update Fantom icon color for Sonic rebrand

### DIFF
--- a/.changeset/fix-fantom-color-sonic.md
+++ b/.changeset/fix-fantom-color-sonic.md
@@ -1,0 +1,5 @@
+---
+"react-web3-icons": patch
+---
+
+fix(chain): update Fantom icon color to reflect Sonic rebrand

--- a/src/chain/Fantom.tsx
+++ b/src/chain/Fantom.tsx
@@ -7,8 +7,8 @@ const FANTOM_BARS =
 
 export const Fantom = createIcon('Fantom', '0 0 24 24', () => (
   <>
-    <path d={FANTOM_GEM} fill="#26B6EA" fillRule="evenodd" clipRule="evenodd" />
-    <path d={FANTOM_BARS} fill="#26B6EA" />
+    <path d={FANTOM_GEM} fill="#F37A29" fillRule="evenodd" clipRule="evenodd" />
+    <path d={FANTOM_BARS} fill="#F37A29" />
   </>
 ));
 


### PR DESCRIPTION
## Summary

- Update Fantom chain icon fill color from legacy teal `#26B6EA` to Sonic brand orange `#F37A29`
- The Fantom chain rebranded to Sonic in 2024; the icon shape remains the same but the brand color changed

## Related issue

Closes #465

## Checklist

- [x] Visual change verified (before/after color confirmed)
- [x] `pnpm run check` passed
- [x] `pnpm run typecheck` passed
- [x] `pnpm test` passed
- [x] `pnpm run build` passed
- [x] Changeset added
- [ ] Breaking change: No

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **バグ修正**
  * Fantomアイコンの表示色を更新しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->