### PR TITLE
refactor: migrate manual forwardRef icons to createIcon

### DIFF
--- a/.changeset/refactor-createicon-migration.md
+++ b/.changeset/refactor-createicon-migration.md
@@ -1,0 +1,5 @@
+---
+"react-web3-icons": patch
+---
+
+refactor: migrate manual forwardRef icons to createIcon utility

--- a/src/exchange/Coinbase.tsx
+++ b/src/exchange/Coinbase.tsx
@@ -1,73 +1,36 @@
-import { forwardRef } from 'react';
-import type { IconProps } from '../utils';
 import { createIcon } from '../utils';
-import { useIconContext } from '../utils/IconContext';
 
-interface CoinbaseProps extends IconProps {
-  fill1?: string;
-  fill2?: string;
-}
+const COINBASE_BG =
+  'M1250 0h0c690.2 0 1250 559.8 1250 1250h0c0 690.2-559.8 1250-1250 1250h0C559.8 2500 0 1940.2 0 1250h0C0 559.8 559.8 0 1250 0z';
+const COINBASE_C =
+  'M1250.4 1689.5c-242.8 0-439.4-196.7-439.4-439.5s196.7-439.4 439.4-439.4c217.5 0 398.1 158.6 432.9 366.2H2126c-37.4-451.2-414.9-805.7-875.6-805.7-485.2 0-878.9 393.7-878.9 878.9s393.7 878.9 878.9 878.9c460.7 0 838.3-354.5 875.6-805.7h-443.1c-34.8 207.7-215 366.3-432.5 366.3h0z';
 
-const CoinbaseBase = forwardRef<SVGSVGElement, CoinbaseProps>(
-  function CoinbaseBase({ fill1, fill2, ...rawProps }, ref) {
-    const {
-      title,
-      titleId,
-      size = '1em',
-      width,
-      height,
-      ...props
-    } = useIconContext(rawProps);
-    const isDecorative = !(
-      title ||
-      props['aria-label'] ||
-      props['aria-labelledby']
-    );
-    return (
-      <svg
-        xmlns="http://www.w3.org/2000/svg"
-        viewBox="0 0 2500 2500"
-        width={width ?? size}
-        height={height ?? size}
-        aria-hidden={isDecorative || undefined}
-        role={isDecorative ? undefined : 'img'}
-        ref={ref}
-        {...props}
-      >
-        {title && <title id={titleId}>{title}</title>}
-        <path
-          d="M1250 0h0c690.2 0 1250 559.8 1250 1250h0c0 690.2-559.8 1250-1250 1250h0C559.8 2500 0 1940.2 0 1250h0C0 559.8 559.8 0 1250 0z"
-          fill={fill1}
-        />
-        <path
-          d="M1250.4 1689.5c-242.8 0-439.4-196.7-439.4-439.5s196.7-439.4 439.4-439.4c217.5 0 398.1 158.6 432.9 366.2H2126c-37.4-451.2-414.9-805.7-875.6-805.7-485.2 0-878.9 393.7-878.9 878.9s393.7 878.9 878.9 878.9c460.7 0 838.3-354.5 875.6-805.7h-443.1c-34.8 207.7-215 366.3-432.5 366.3h0z"
-          fill={fill2}
-        />
-      </svg>
-    );
-  },
+export const CoinbaseCircle = createIcon(
+  'CoinbaseCircle',
+  '0 0 2500 2500',
+  () => (
+    <>
+      <path d={COINBASE_BG} fill="#fff" />
+      <path d={COINBASE_C} fill="#0052ff" />
+    </>
+  ),
 );
 
-const coinbaseBase2Content = () => (
-  <path d="M1250.4 1689.5c-242.8 0-439.4-196.7-439.4-439.5s196.7-439.4 439.4-439.4c217.5 0 398.1 158.6 432.9 366.2H2126c-37.4-451.2-414.9-805.7-875.6-805.7-485.2 0-878.9 393.7-878.9 878.9s393.7 878.9 878.9 878.9c460.7 0 838.3-354.5 875.6-805.7h-443.1c-34.8 207.7-215 366.3-432.5 366.3h0z" />
-);
-
-export const CoinbaseCircle = forwardRef<SVGSVGElement, IconProps>(
-  function CoinbaseCircle(props, ref) {
-    return <CoinbaseBase fill1="#fff" fill2="#0052ff" {...props} ref={ref} />;
-  },
-);
-
-export const CoinbaseCircleAlt = forwardRef<SVGSVGElement, IconProps>(
-  function CoinbaseCircleAlt(props, ref) {
-    return <CoinbaseBase fill1="#0052ff" fill2="#fff" {...props} ref={ref} />;
-  },
+export const CoinbaseCircleAlt = createIcon(
+  'CoinbaseCircleAlt',
+  '0 0 2500 2500',
+  () => (
+    <>
+      <path d={COINBASE_BG} fill="#0052ff" />
+      <path d={COINBASE_C} fill="#fff" />
+    </>
+  ),
 );
 
 export const Coinbase = createIcon(
   'Coinbase',
   '371.5 371.1 1754.5 1757.8',
-  coinbaseBase2Content,
+  () => <path d={COINBASE_C} />,
   '#0052ff',
 );
 
@@ -79,16 +42,10 @@ export const CoinbaseCircleMono = createIcon(
       <defs>
         <mask id={`${_id}-cbem-a`}>
           <rect width="100%" height="100%" fill="#fff" />
-          <path
-            d="M1250.4 1689.5c-242.8 0-439.4-196.7-439.4-439.5s196.7-439.4 439.4-439.4c217.5 0 398.1 158.6 432.9 366.2H2126c-37.4-451.2-414.9-805.7-875.6-805.7-485.2 0-878.9 393.7-878.9 878.9s393.7 878.9 878.9 878.9c460.7 0 838.3-354.5 875.6-805.7h-443.1c-34.8 207.7-215 366.3-432.5 366.3h0z"
-            fill="#000"
-          />
+          <path d={COINBASE_C} fill="#000" />
         </mask>
       </defs>
-      <path
-        d="M1250 0h0c690.2 0 1250 559.8 1250 1250h0c0 690.2-559.8 1250-1250 1250h0C559.8 2500 0 1940.2 0 1250h0C0 559.8 559.8 0 1250 0z"
-        mask={`url(#${_id}-cbem-a)`}
-      />
+      <path d={COINBASE_BG} mask={`url(#${_id}-cbem-a)`} />
     </>
   ),
   'currentColor',
@@ -97,6 +54,6 @@ export const CoinbaseCircleMono = createIcon(
 export const CoinbaseMono = createIcon(
   'CoinbaseMono',
   '371.5 371.1 1754.5 1757.8',
-  coinbaseBase2Content,
+  () => <path d={COINBASE_C} />,
   'currentColor',
 );

--- a/src/explorer/Bscscan.tsx
+++ b/src/explorer/Bscscan.tsx
@@ -1,67 +1,36 @@
-import { forwardRef } from 'react';
-import type { IconProps } from '../utils';
-import { useIconContext } from '../utils/IconContext';
+import { createIcon } from '../utils';
 
-interface BscscanProps extends IconProps {
-  fill1?: string;
-  fill2?: string;
-}
+const BSCSCAN_BODY =
+  'M25.222 57.766c0-1.368.546-2.68 1.515-3.645s2.284-1.504 3.653-1.498l8.568.028a5.15 5.15 0 0 1 5.151 5.151v32.4l3.559-.911a4.29 4.29 0 0 0 3.309-4.177V44.927c0-2.845 2.306-5.151 5.151-5.152h8.594c2.845.001 5.151 2.307 5.151 5.152v37.3l4.243-1.754a4.3 4.3 0 0 0 2.625-3.957V32.049a5.15 5.15 0 0 1 5.15-5.151h8.585a5.15 5.15 0 0 1 5.146 5.151v36.617c7.443-5.394 14.986-11.882 20.972-19.683 1.764-2.3 2.258-5.331 1.316-8.072A60.64 60.64 0 0 0 68.303.67 60.64 60.64 0 0 0 8.055 91.019a7.67 7.67 0 0 0 7.316 3.79c1.624-.143 3.646-.345 6.05-.627a4.29 4.29 0 0 0 3.805-4.258V57.766';
+const BSCSCAN_TAIL =
+  'M25.039 109.727a60.66 60.66 0 0 0 96.339-49.061l-.158-4.152c-22.163 33.055-63.085 48.508-96.181 53.213';
 
-const BscscanBase = forwardRef<SVGSVGElement, BscscanProps>(
-  function BscscanBase({ fill1, fill2, ...rawProps }, ref) {
-    const {
-      title,
-      titleId,
-      size = '1em',
-      width,
-      height,
-      ...props
-    } = useIconContext(rawProps);
-    const isDecorative = !(
-      title ||
-      props['aria-label'] ||
-      props['aria-labelledby']
-    );
-    return (
-      <svg
-        xmlns="http://www.w3.org/2000/svg"
-        viewBox="0 0.18 121.38 121.15"
-        width={width ?? size}
-        height={height ?? size}
-        aria-hidden={isDecorative || undefined}
-        role={isDecorative ? undefined : 'img'}
-        ref={ref}
-        {...props}
-      >
-        {title && <title id={titleId}>{title}</title>}
-        <path
-          d="M25.222 57.766c0-1.368.546-2.68 1.515-3.645s2.284-1.504 3.653-1.498l8.568.028a5.15 5.15 0 0 1 5.151 5.151v32.4l3.559-.911a4.29 4.29 0 0 0 3.309-4.177V44.927c0-2.845 2.306-5.151 5.151-5.152h8.594c2.845.001 5.151 2.307 5.151 5.152v37.3l4.243-1.754a4.3 4.3 0 0 0 2.625-3.957V32.049a5.15 5.15 0 0 1 5.15-5.151h8.585a5.15 5.15 0 0 1 5.146 5.151v36.617c7.443-5.394 14.986-11.882 20.972-19.683 1.764-2.3 2.258-5.331 1.316-8.072A60.64 60.64 0 0 0 68.303.67 60.64 60.64 0 0 0 8.055 91.019a7.67 7.67 0 0 0 7.316 3.79c1.624-.143 3.646-.345 6.05-.627a4.29 4.29 0 0 0 3.805-4.258V57.766"
-          fill={fill1}
-        />
-        <path
-          d="M25.039 109.727a60.66 60.66 0 0 0 96.339-49.061l-.158-4.152c-22.163 33.055-63.085 48.508-96.181 53.213"
-          fill={fill2}
-        />
-      </svg>
-    );
-  },
+export const Bscscan = createIcon('Bscscan', '0 0.18 121.38 121.15', () => (
+  <>
+    <path d={BSCSCAN_BODY} fill="#12161c" />
+    <path d={BSCSCAN_TAIL} fill="#f0b90b" />
+  </>
+));
+
+export const BscscanLight = createIcon(
+  'BscscanLight',
+  '0 0.18 121.38 121.15',
+  () => (
+    <>
+      <path d={BSCSCAN_BODY} fill="#fff" />
+      <path d={BSCSCAN_TAIL} fill="#f0b90b" />
+    </>
+  ),
 );
 
-export const Bscscan = forwardRef<SVGSVGElement, IconProps>(
-  function Bscscan(props, ref) {
-    return <BscscanBase fill1="#12161c" fill2="#f0b90b" {...props} ref={ref} />;
-  },
-);
-
-export const BscscanLight = forwardRef<SVGSVGElement, IconProps>(
-  function BscscanLight(props, ref) {
-    return <BscscanBase fill1="#fff" fill2="#f0b90b" {...props} ref={ref} />;
-  },
-);
-
-export const BscscanMono = forwardRef<SVGSVGElement, IconProps>(
-  function BscscanMono(props, ref) {
-    const color = props.fill ?? 'currentColor';
-    return <BscscanBase fill1={color} fill2={color} {...props} ref={ref} />;
-  },
+export const BscscanMono = createIcon(
+  'BscscanMono',
+  '0 0.18 121.38 121.15',
+  () => (
+    <>
+      <path d={BSCSCAN_BODY} />
+      <path d={BSCSCAN_TAIL} />
+    </>
+  ),
+  'currentColor',
 );

--- a/src/explorer/Solscan.tsx
+++ b/src/explorer/Solscan.tsx
@@ -1,61 +1,25 @@
-import { forwardRef } from 'react';
-import type { IconProps } from '../utils';
-import { useIconContext } from '../utils/IconContext';
+import { createIcon } from '../utils';
 
-interface SolscanProps extends IconProps {
-  fill1?: string;
-  fill2?: string;
-}
+const SOLSCAN_DOT =
+  'M106.387 152.73a3.14 3.14 0 0 1-.088 6.311 3.14 3.14 0 1 1 .088-6.311z';
+const SOLSCAN_ARC =
+  'M110.483 162.623c-2.751 2.216-7.667 1.423-10.214-1.559-2.801-3.28-2.474-8.201.739-11.115a7.99 7.99 0 0 1 11.077.359c2.905 2.987 3.034 7.944.315 10.741l-1.937-2.029c1.031-1.441 1.35-3.09.734-4.861-.92-2.644-3.835-4.039-6.494-3.138-2.627.891-4.065 3.719-3.245 6.381.83 2.692 3.643 4.221 6.343 3.391.538-.165.836-.068 1.184.332.459.53.991.997 1.498 1.498z';
 
-const SolscanBase = forwardRef<SVGSVGElement, SolscanProps>(
-  function SolscanBase({ fill1, fill2, ...rawProps }, ref) {
-    const {
-      title,
-      titleId,
-      size = '1em',
-      width,
-      height,
-      ...props
-    } = useIconContext(rawProps);
-    const isDecorative = !(
-      title ||
-      props['aria-label'] ||
-      props['aria-labelledby']
-    );
-    return (
-      <svg
-        xmlns="http://www.w3.org/2000/svg"
-        viewBox="98.37 147.89 15.99 16"
-        width={width ?? size}
-        height={height ?? size}
-        aria-hidden={isDecorative || undefined}
-        role={isDecorative ? undefined : 'img'}
-        ref={ref}
-        {...props}
-      >
-        {title && <title id={titleId}>{title}</title>}
-        <path
-          d="M106.387 152.73a3.14 3.14 0 0 1-.088 6.311 3.14 3.14 0 1 1 .088-6.311z"
-          fill={fill1}
-        />
-        <path
-          d="M110.483 162.623c-2.751 2.216-7.667 1.423-10.214-1.559-2.801-3.28-2.474-8.201.739-11.115a7.99 7.99 0 0 1 11.077.359c2.905 2.987 3.034 7.944.315 10.741l-1.937-2.029c1.031-1.441 1.35-3.09.734-4.861-.92-2.644-3.835-4.039-6.494-3.138-2.627.891-4.065 3.719-3.245 6.381.83 2.692 3.643 4.221 6.343 3.391.538-.165.836-.068 1.184.332.459.53.991.997 1.498 1.498z"
-          fill={fill2}
-        />
-      </svg>
-    );
-  },
-);
+export const Solscan = createIcon('Solscan', '98.37 147.89 15.99 16', () => (
+  <>
+    <path d={SOLSCAN_DOT} fill="#c74ae3" />
+    <path d={SOLSCAN_ARC} fill="#00e8b5" />
+  </>
+));
 
-export const Solscan = forwardRef<SVGSVGElement, IconProps>(
-  function Solscan(props, ref) {
-    return <SolscanBase fill1="#c74ae3" fill2="#00e8b5" {...props} ref={ref} />;
-  },
-);
-
-export const SolscanMono = forwardRef<SVGSVGElement, IconProps>(
-  function SolscanMono(props, ref) {
-    const color = props.fill ?? 'currentColor';
-    return <SolscanBase fill1={color} fill2={color} {...props} ref={ref} />;
-  },
+export const SolscanMono = createIcon(
+  'SolscanMono',
+  '98.37 147.89 15.99 16',
+  () => (
+    <>
+      <path d={SOLSCAN_DOT} />
+      <path d={SOLSCAN_ARC} />
+    </>
+  ),
+  'currentColor',
 );

--- a/src/portfolio/Coinpanda.tsx
+++ b/src/portfolio/Coinpanda.tsx
@@ -1,145 +1,78 @@
-import { type ForwardedRef, forwardRef, useId } from 'react';
+import { createIcon } from '../utils';
 
-import { createIcon, type IconProps } from '../utils';
-import { useIconContext } from '../utils/IconContext';
+const COINPANDA_MARK =
+  'M33.212 1.097c-3.636 0-6.608 2.896-6.731 6.502-4.155-1.822-8.864-1.821-13.016 0-.123-3.605-3.095-6.502-6.731-6.502C3.021 1.097 0 4.118 0 7.832c0 3.384 2.499 6.201 5.792 6.661-1.412 2.469-2.156 5.247-2.156 8.072a16.36 16.36 0 0 0 16.338 16.338 16.36 16.36 0 0 0 16.338-16.338c0-2.825-.744-5.603-2.156-8.072 3.294-.46 5.793-3.277 5.793-6.661a6.75 6.75 0 0 0-6.737-6.735zM6.734 11.298a3.47 3.47 0 0 1-3.465-3.465 3.47 3.47 0 0 1 3.465-3.466A3.47 3.47 0 0 1 10.2 7.833a3.47 3.47 0 0 1-3.466 3.465zm26.309 11.268c0 7.206-5.863 13.068-13.069 13.068S6.905 29.772 6.905 22.566 12.767 9.497 19.973 9.497a13.09 13.09 0 0 1 13.07 13.069zM29.747 7.833a3.47 3.47 0 0 1 3.466-3.466 3.47 3.47 0 0 1 3.466 3.466 3.47 3.47 0 0 1-3.466 3.465 3.47 3.47 0 0 1-3.466-3.465z';
 
-const coinpandaContent = () => (
-  <path d="M33.212 1.097c-3.636 0-6.608 2.896-6.731 6.502-4.155-1.822-8.864-1.821-13.016 0-.123-3.605-3.095-6.502-6.731-6.502C3.021 1.097 0 4.118 0 7.832c0 3.384 2.499 6.201 5.792 6.661-1.412 2.469-2.156 5.247-2.156 8.072a16.36 16.36 0 0 0 16.338 16.338 16.36 16.36 0 0 0 16.338-16.338c0-2.825-.744-5.603-2.156-8.072 3.294-.46 5.793-3.277 5.793-6.661a6.75 6.75 0 0 0-6.737-6.735zM6.734 11.298a3.47 3.47 0 0 1-3.465-3.465 3.47 3.47 0 0 1 3.465-3.466A3.47 3.47 0 0 1 10.2 7.833a3.47 3.47 0 0 1-3.466 3.465zm26.309 11.268c0 7.206-5.863 13.068-13.069 13.068S6.905 29.772 6.905 22.566 12.767 9.497 19.973 9.497a13.09 13.09 0 0 1 13.07 13.069zM29.747 7.833a3.47 3.47 0 0 1 3.466-3.466 3.47 3.47 0 0 1 3.466 3.466 3.47 3.47 0 0 1-3.466 3.465 3.47 3.47 0 0 1-3.466-3.465z" />
-);
+// Scaled version used in the 86×86 background variants
+const COINPANDA_BG_SYMBOL =
+  'M59.22 19.84c-4.455 0-8.097 3.548-8.247 7.967a19.83 19.83 0 0 0-15.948 0c-.151-4.418-3.793-7.968-8.247-7.968-4.549 0-8.251 3.702-8.251 8.252a8.24 8.24 0 0 0 7.097 8.162c-1.73 3.025-2.642 6.429-2.642 9.891 0 11.039 8.98 20.019 20.019 20.019s20.019-8.98 20.019-20.019c0-3.461-.912-6.865-2.642-9.891a8.24 8.24 0 0 0 7.098-8.162 8.27 8.27 0 0 0-8.255-8.251h0zM26.775 32.338c-2.34 0-4.246-1.905-4.246-4.246s1.905-4.247 4.246-4.247 4.247 1.905 4.247 4.247a4.25 4.25 0 0 1-4.247 4.246zm32.236 13.807c0 8.829-7.184 16.012-16.013 16.012s-16.013-7.183-16.013-16.012 7.184-16.013 16.013-16.013 16.013 7.184 16.013 16.013zm-4.039-18.052c0-2.342 1.905-4.247 4.247-4.247s4.247 1.905 4.247 4.247a4.25 4.25 0 0 1-4.247 4.246 4.25 4.25 0 0 1-4.247-4.246z';
 
 export const Coinpanda = createIcon(
   'Coinpanda',
   '0 1.1 39.95 37.81',
-  coinpandaContent,
+  () => <path d={COINPANDA_MARK} />,
   '#246aff',
 );
 
 export const CoinpandaMono = createIcon(
   'CoinpandaMono',
   '0 1.1 39.95 37.81',
-  coinpandaContent,
+  () => <path d={COINPANDA_MARK} />,
   'currentColor',
 );
 
-interface PropsWithBackground extends IconProps {
-  background: 'circle' | 'rect';
-}
-
-const CoinpandaBase = forwardRef(
-  (
-    { background, ...rawProps }: PropsWithBackground,
-    ref: ForwardedRef<SVGSVGElement>,
-  ) => {
-    const {
-      title,
-      titleId,
-      size = '1em',
-      width,
-      height,
-      ...props
-    } = useIconContext(rawProps);
-    const isDecorative = !(
-      title ||
-      props['aria-label'] ||
-      props['aria-labelledby']
-    );
-    return (
-      <svg
-        ref={ref}
-        viewBox="0 0 86 86"
-        width={width ?? size}
-        height={height ?? size}
-        aria-hidden={isDecorative || undefined}
-        role={isDecorative ? undefined : 'img'}
-        {...props}
-      >
-        {title && <title id={titleId}>{title}</title>}
-        {background === 'circle' ? (
-          <circle fill="#246aff" cx="43" cy="43" r="43" />
-        ) : (
-          <rect fill="#246aff" width="86" height="86" />
-        )}
-        <path
-          fill="#fff"
-          d="M59.22 19.84c-4.455 0-8.097 3.548-8.247 7.967a19.83 19.83 0 0 0-15.948 0c-.151-4.418-3.793-7.968-8.247-7.968-4.549 0-8.251 3.702-8.251 8.252a8.24 8.24 0 0 0 7.097 8.162c-1.73 3.025-2.642 6.429-2.642 9.891 0 11.039 8.98 20.019 20.019 20.019s20.019-8.98 20.019-20.019c0-3.461-.912-6.865-2.642-9.891a8.24 8.24 0 0 0 7.098-8.162 8.27 8.27 0 0 0-8.255-8.251h0zM26.775 32.338c-2.34 0-4.246-1.905-4.246-4.246s1.905-4.247 4.246-4.247 4.247 1.905 4.247 4.247a4.25 4.25 0 0 1-4.247 4.246zm32.236 13.807c0 8.829-7.184 16.012-16.013 16.012s-16.013-7.183-16.013-16.012 7.184-16.013 16.013-16.013 16.013 7.184 16.013 16.013zm-4.039-18.052c0-2.342 1.905-4.247 4.247-4.247s4.247 1.905 4.247 4.247a4.25 4.25 0 0 1-4.247 4.246 4.25 4.25 0 0 1-4.247-4.246z"
-        />
-      </svg>
-    );
-  },
-);
-CoinpandaBase.displayName = 'CoinpandaBase';
-
-export const CoinpandaCircle = forwardRef<SVGSVGElement, IconProps>(
-  function CoinpandaCircle(props, ref) {
-    return <CoinpandaBase background="circle" {...props} ref={ref} />;
-  },
+export const CoinpandaCircle = createIcon(
+  'CoinpandaCircle',
+  '0 0 86 86',
+  () => (
+    <>
+      <circle fill="#246aff" cx="43" cy="43" r="43" />
+      <path fill="#fff" d={COINPANDA_BG_SYMBOL} />
+    </>
+  ),
 );
 
-export const CoinpandaSquare = forwardRef<SVGSVGElement, IconProps>(
-  function CoinpandaSquare(props, ref) {
-    return <CoinpandaBase background="rect" {...props} ref={ref} />;
-  },
+export const CoinpandaSquare = createIcon(
+  'CoinpandaSquare',
+  '0 0 86 86',
+  () => (
+    <>
+      <rect fill="#246aff" width="86" height="86" />
+      <path fill="#fff" d={COINPANDA_BG_SYMBOL} />
+    </>
+  ),
 );
 
-const CoinpandaMonoBase = forwardRef(
-  (
-    { background, ...rawProps }: PropsWithBackground,
-    ref: ForwardedRef<SVGSVGElement>,
-  ) => {
-    const {
-      title,
-      titleId,
-      size = '1em',
-      width,
-      height,
-      ...props
-    } = useIconContext(rawProps);
-    const _id = useId();
-    const isDecorative = !(
-      title ||
-      props['aria-label'] ||
-      props['aria-labelledby']
-    );
-    return (
-      <svg
-        ref={ref}
-        viewBox="0 0 86 86"
-        width={width ?? size}
-        height={height ?? size}
-        fill="currentColor"
-        aria-hidden={isDecorative || undefined}
-        role={isDecorative ? undefined : 'img'}
-        {...props}
-      >
-        {title && <title id={titleId}>{title}</title>}
-        {background === 'circle' ? (
-          <circle cx="43" cy="43" r="43" mask={`url(#${_id}-cpd-a)`} />
-        ) : (
-          <rect width="86" height="86" mask={`url(#${_id}-cpd-a)`} />
-        )}
-        <defs>
-          <mask id={`${_id}-cpd-a`}>
-            <rect width="100%" height="100%" fill="#fff" />
-            <path
-              d="M59.22 19.84c-4.455 0-8.097 3.548-8.247 7.967a19.83 19.83 0 0 0-15.948 0c-.151-4.418-3.793-7.968-8.247-7.968-4.549 0-8.251 3.702-8.251 8.252a8.24 8.24 0 0 0 7.097 8.162c-1.73 3.025-2.642 6.429-2.642 9.891 0 11.039 8.98 20.019 20.019 20.019s20.019-8.98 20.019-20.019c0-3.461-.912-6.865-2.642-9.891a8.24 8.24 0 0 0 7.098-8.162 8.27 8.27 0 0 0-8.255-8.251h0zM26.775 32.338c-2.34 0-4.246-1.905-4.246-4.246s1.905-4.247 4.246-4.247 4.247 1.905 4.247 4.247a4.25 4.25 0 0 1-4.247 4.246zm32.236 13.807c0 8.829-7.184 16.012-16.013 16.012s-16.013-7.183-16.013-16.012 7.184-16.013 16.013-16.013 16.013 7.184 16.013 16.013zm-4.039-18.052c0-2.342 1.905-4.247 4.247-4.247s4.247 1.905 4.247 4.247a4.25 4.25 0 0 1-4.247 4.246 4.25 4.25 0 0 1-4.247-4.246z"
-              fill="#000"
-            />
-          </mask>
-        </defs>
-      </svg>
-    );
-  },
-);
-CoinpandaMonoBase.displayName = 'CoinpandaMonoBase';
-
-export const CoinpandaCircleMono = forwardRef<SVGSVGElement, IconProps>(
-  function CoinpandaCircleMono(props, ref) {
-    return <CoinpandaMonoBase background="circle" {...props} ref={ref} />;
-  },
+export const CoinpandaCircleMono = createIcon(
+  'CoinpandaCircleMono',
+  '0 0 86 86',
+  _id => (
+    <>
+      <circle cx="43" cy="43" r="43" mask={`url(#${_id}-cpd-a)`} />
+      <defs>
+        <mask id={`${_id}-cpd-a`}>
+          <rect width="100%" height="100%" fill="#fff" />
+          <path d={COINPANDA_BG_SYMBOL} fill="#000" />
+        </mask>
+      </defs>
+    </>
+  ),
+  'currentColor',
 );
 
-export const CoinpandaSquareMono = forwardRef<SVGSVGElement, IconProps>(
-  function CoinpandaSquareMono(props, ref) {
-    return <CoinpandaMonoBase background="rect" {...props} ref={ref} />;
-  },
+export const CoinpandaSquareMono = createIcon(
+  'CoinpandaSquareMono',
+  '0 0 86 86',
+  _id => (
+    <>
+      <rect width="86" height="86" mask={`url(#${_id}-cpds-a)`} />
+      <defs>
+        <mask id={`${_id}-cpds-a`}>
+          <rect width="100%" height="100%" fill="#fff" />
+          <path d={COINPANDA_BG_SYMBOL} fill="#000" />
+        </mask>
+      </defs>
+    </>
+  ),
+  'currentColor',
 );


### PR DESCRIPTION
## Summary

Migrate four icon files from manual `forwardRef` + `useIconContext` boilerplate to the `createIcon` factory:

- `src/explorer/Bscscan.tsx` — removed `BscscanBase` wrapper, 3 exports
- `src/explorer/Solscan.tsx` — removed `SolscanBase` wrapper, 2 exports
- `src/exchange/Coinbase.tsx` — removed `CoinbaseBase` wrapper, 5 exports (all variants now use `createIcon`)
- `src/portfolio/Coinpanda.tsx` — removed `CoinpandaBase`/`CoinpandaMonoBase` wrappers, 6 exports

All shared SVG path data extracted into named constants. No API changes; behavior is identical.

**Deferred** (breaking API changes):
- `src/exchange/Bybit.tsx` — exposes `fill1`/`fill2` custom props
- `src/chain/Avalanche.tsx` — exposes `withBackground` custom prop

## Related issue

Closes #466

## Checklist

- [x] `pnpm run check` passed
- [x] `pnpm run typecheck` passed
- [x] `pnpm test` passed (2898 tests)
- [x] `pnpm run build` passed
- [x] Changeset added
- [ ] Breaking change: No