### PR TITLE
feat(wallet): add Square variants for top wallet icons

### DIFF
--- a/.changeset/add-wallet-square-variants.md
+++ b/.changeset/add-wallet-square-variants.md
@@ -1,0 +1,5 @@
+---
+'react-web3-icons': minor
+---
+
+Add Square variants for top wallet icons

--- a/src/wallet/CoinbaseWallet.tsx
+++ b/src/wallet/CoinbaseWallet.tsx
@@ -60,6 +60,36 @@ export const CoinbaseWalletCircleMono = createIcon(
   'currentColor',
 );
 
+export const CoinbaseWalletSquare = createIcon(
+  'CoinbaseWalletSquare',
+  '0 0 64 64',
+  () => (
+    <>
+      <rect width="64" height="64" rx="12.8" fill="#0052ff" />
+      <path d={CB_WHITE_CIRCLE} transform={CB_CIRCLE_TX} fill="#fff" />
+      <path d={CB_INNER_RECT} transform={CB_CIRCLE_TX} fill="#0052ff" />
+    </>
+  ),
+);
+
+export const CoinbaseWalletSquareMono = createIcon(
+  'CoinbaseWalletSquareMono',
+  '0 0 64 64',
+  _id => (
+    <>
+      <rect width="64" height="64" rx="12.8" mask={`url(#${_id}-cbsqm-a)`} />
+      <defs>
+        <mask id={`${_id}-cbsqm-a`}>
+          <rect width="100%" height="100%" fill="#fff" />
+          <path d={CB_WHITE_CIRCLE} transform={CB_CIRCLE_TX} fill="#000" />
+        </mask>
+      </defs>
+      <path d={CB_INNER_RECT} transform={CB_CIRCLE_TX} />
+    </>
+  ),
+  'currentColor',
+);
+
 export const CoinbaseWalletMono = createIcon(
   'CoinbaseWalletMono',
   '0 0 2500 2500',

--- a/src/wallet/MetaMask.tsx
+++ b/src/wallet/MetaMask.tsx
@@ -111,6 +111,34 @@ export const MetaMaskCircleMono = createIcon(
   'currentColor',
 );
 
+export const MetaMaskSquare = createIcon('MetaMaskSquare', '0 0 64 64', () => (
+  <>
+    <rect width="64" height="64" rx="12.8" fill="#F6851B" />
+    <g transform={MM_CIRCLE_TX} fill="#fff">
+      {metaMaskMonoPaths()}
+    </g>
+  </>
+));
+
+export const MetaMaskSquareMono = createIcon(
+  'MetaMaskSquareMono',
+  '0 0 64 64',
+  _id => (
+    <>
+      <rect width="64" height="64" rx="12.8" mask={`url(#${_id}-mmsq-a)`} />
+      <defs>
+        <mask id={`${_id}-mmsq-a`}>
+          <rect width="100%" height="100%" fill="#fff" />
+          <g transform={MM_CIRCLE_TX} fill="#000">
+            {metaMaskMonoPaths()}
+          </g>
+        </mask>
+      </defs>
+    </>
+  ),
+  'currentColor',
+);
+
 export const MetaMaskAlt = createIcon('MetaMaskAlt', '0 0 404 420.2', () => (
   <>
     <path

--- a/src/wallet/PhantomWallet.tsx
+++ b/src/wallet/PhantomWallet.tsx
@@ -102,6 +102,47 @@ export const PhantomWalletCircleMono = createIcon(
   'currentColor',
 );
 
+export const PhantomWalletSquare = createIcon(
+  'PhantomWalletSquare',
+  '0 0 64 64',
+  _id => (
+    <>
+      <rect width="64" height="64" rx="12.8" fill={`url(#${_id}-phsq-a)`} />
+      <path d={PHANTOM_GHOST} transform={PH_CIRCLE_TX} fill="#fff" />
+      <defs>
+        <linearGradient
+          id={`${_id}-phsq-a`}
+          x1="32"
+          y1="0"
+          x2="32"
+          y2="64"
+          gradientUnits="userSpaceOnUse"
+        >
+          <stop stopColor="#534bb1" />
+          <stop offset="1" stopColor="#551bf9" />
+        </linearGradient>
+      </defs>
+    </>
+  ),
+);
+
+export const PhantomWalletSquareMono = createIcon(
+  'PhantomWalletSquareMono',
+  '0 0 64 64',
+  _id => (
+    <>
+      <rect width="64" height="64" rx="12.8" mask={`url(#${_id}-phsqm-a)`} />
+      <defs>
+        <mask id={`${_id}-phsqm-a`}>
+          <rect width="100%" height="100%" fill="#fff" />
+          <path d={PHANTOM_GHOST} transform={PH_CIRCLE_TX} fill="#000" />
+        </mask>
+      </defs>
+    </>
+  ),
+  'currentColor',
+);
+
 export const PhantomWalletSymbolMono = createIcon(
   'PhantomWalletSymbolMono',
   '0 0 128 106',

--- a/src/wallet/RainbowWallet.tsx
+++ b/src/wallet/RainbowWallet.tsx
@@ -371,6 +371,173 @@ export const RainbowWalletCircleMono = createIcon(
   'currentColor',
 );
 
+export const RainbowWalletSquare = createIcon(
+  'RainbowWalletSquare',
+  '0 0 64 64',
+  _id => (
+    <>
+      <rect width="64" height="64" rx="12.8" fill={`url(#${_id}-rbwsq-bg)`} />
+      <g transform={RBW_CIRCLE_TX}>
+        <path
+          d="M20 38h6c30.928 0 56 25.072 56 56v6h12a6 6 0 0 0 6-6c0-40.869-33.131-74-74-74a6 6 0 0 0-6 6v12z"
+          fill={`url(#${_id}-rbwsq-b)`}
+        />
+        <path
+          d="M84 94h16a6 6 0 0 1-6 6H84v-6z"
+          fill={`url(#${_id}-rbwsq-c)`}
+        />
+        <path
+          d="M26 20v16h-6V26a6 6 0 0 1 6-6z"
+          fill={`url(#${_id}-rbwsq-d)`}
+        />
+        <path
+          d="M20 36h6c32.033 0 58 25.968 58 58v6H66v-6c0-22.091-17.909-40-40-40h-6V36z"
+          fill={`url(#${_id}-rbwsq-e)`}
+        />
+        <path d="M68 94h16v6H68v-6z" fill={`url(#${_id}-rbwsq-f)`} />
+        <path d="M20 52V36h6v16h-6z" fill={`url(#${_id}-rbwsq-g)`} />
+        <path
+          d="M20 62a6 6 0 0 0 6 6c14.359 0 26 11.641 26 26a6 6 0 0 0 6 6h10v-6c0-23.196-18.804-42-42-42h-6v10z"
+          fill={`url(#${_id}-rbwsq-h)`}
+        />
+        <path d="M52 94h16v6H58a6 6 0 0 1-6-6z" fill={`url(#${_id}-rbwsq-i)`} />
+        <path d="M26 68a6 6 0 0 1-6-6V52h6v16z" fill={`url(#${_id}-rbwsq-j)`} />
+      </g>
+      <defs>
+        <linearGradient
+          id={`${_id}-rbwsq-bg`}
+          x1="32"
+          y1="0"
+          x2="32"
+          y2="64"
+          gradientUnits="userSpaceOnUse"
+        >
+          <stop stopColor="#174299" />
+          <stop offset="1" stopColor="#001e59" />
+        </linearGradient>
+        <radialGradient
+          id={`${_id}-rbwsq-b`}
+          cx="0"
+          cy="0"
+          r="1"
+          gradientTransform="translate(26 94) rotate(-90) scale(74)"
+          gradientUnits="userSpaceOnUse"
+        >
+          <stop offset=".77" stopColor="#ff4000" />
+          <stop offset="1" stopColor="#8754c9" />
+        </radialGradient>
+        <linearGradient
+          id={`${_id}-rbwsq-c`}
+          x1="83"
+          y1="97"
+          x2="100"
+          y2="97"
+          gradientUnits="userSpaceOnUse"
+        >
+          <stop stopColor="#ff4000" />
+          <stop offset="1" stopColor="#8754c9" />
+        </linearGradient>
+        <linearGradient
+          id={`${_id}-rbwsq-d`}
+          x1="23"
+          y1="20"
+          x2="23"
+          y2="37"
+          gradientUnits="userSpaceOnUse"
+        >
+          <stop stopColor="#8754c9" />
+          <stop offset="1" stopColor="#ff4000" />
+        </linearGradient>
+        <radialGradient
+          id={`${_id}-rbwsq-e`}
+          cx="0"
+          cy="0"
+          r="1"
+          gradientTransform="translate(26 94) rotate(-90) scale(58)"
+          gradientUnits="userSpaceOnUse"
+        >
+          <stop offset=".724" stopColor="#fff700" />
+          <stop offset="1" stopColor="#ff9901" />
+        </radialGradient>
+        <linearGradient
+          id={`${_id}-rbwsq-f`}
+          x1="68"
+          y1="97"
+          x2="84"
+          y2="97"
+          gradientUnits="userSpaceOnUse"
+        >
+          <stop stopColor="#fff700" />
+          <stop offset="1" stopColor="#ff9901" />
+        </linearGradient>
+        <linearGradient
+          id={`${_id}-rbwsq-g`}
+          x1="23"
+          y1="52"
+          x2="23"
+          y2="36"
+          gradientUnits="userSpaceOnUse"
+        >
+          <stop stopColor="#fff700" />
+          <stop offset="1" stopColor="#ff9901" />
+        </linearGradient>
+        <radialGradient
+          id={`${_id}-rbwsq-h`}
+          cx="0"
+          cy="0"
+          r="1"
+          gradientTransform="translate(26 94) rotate(-90) scale(42)"
+          gradientUnits="userSpaceOnUse"
+        >
+          <stop offset=".595" stopColor="#0af" />
+          <stop offset="1" stopColor="#01da40" />
+        </radialGradient>
+        <radialGradient
+          id={`${_id}-rbwsq-i`}
+          cx="0"
+          cy="0"
+          r="1"
+          gradientTransform="translate(51 97) scale(17 45.3333)"
+          gradientUnits="userSpaceOnUse"
+        >
+          <stop stopColor="#0af" />
+          <stop offset="1" stopColor="#01da40" />
+        </radialGradient>
+        <radialGradient
+          id={`${_id}-rbwsq-j`}
+          cx="0"
+          cy="0"
+          r="1"
+          gradientTransform="translate(23 69) rotate(-90) scale(17 322.37)"
+          gradientUnits="userSpaceOnUse"
+        >
+          <stop stopColor="#0af" />
+          <stop offset="1" stopColor="#01da40" />
+        </radialGradient>
+      </defs>
+    </>
+  ),
+);
+
+export const RainbowWalletSquareMono = createIcon(
+  'RainbowWalletSquareMono',
+  '0 0 64 64',
+  _id => (
+    <>
+      <rect width="64" height="64" rx="12.8" mask={`url(#${_id}-rbwsqm-a)`} />
+      <defs>
+        <mask id={`${_id}-rbwsqm-a`}>
+          <rect width="100%" height="100%" fill="#fff" />
+          <g transform={RBW_CIRCLE_TX} fill="#000">
+            {rainbowArcPaths()}
+          </g>
+        </mask>
+      </defs>
+    </>
+  ),
+  'currentColor',
+);
+
 export const RainbowWalletMono = createIcon(
   'RainbowWalletMono',
   '0 0 120 120',

--- a/src/wallet/WalletConnect.tsx
+++ b/src/wallet/WalletConnect.tsx
@@ -41,6 +41,38 @@ export const WalletConnectCircleMono = createIcon(
   'currentColor',
 );
 
+export const WalletConnectSquare = createIcon(
+  'WalletConnectSquare',
+  '0 0 64 64',
+  () => (
+    <>
+      <rect width="64" height="64" rx="12.8" fill="#3396FF" />
+      <g transform={WC_CIRCLE_TX} fill="#fff">
+        {walletConnectContent()}
+      </g>
+    </>
+  ),
+);
+
+export const WalletConnectSquareMono = createIcon(
+  'WalletConnectSquareMono',
+  '0 0 64 64',
+  _id => (
+    <>
+      <rect width="64" height="64" rx="12.8" mask={`url(#${_id}-wcsqm-a)`} />
+      <defs>
+        <mask id={`${_id}-wcsqm-a`}>
+          <rect width="100%" height="100%" fill="#fff" />
+          <g transform={WC_CIRCLE_TX} fill="#000">
+            {walletConnectContent()}
+          </g>
+        </mask>
+      </defs>
+    </>
+  ),
+  'currentColor',
+);
+
 export const WalletConnect = createIcon(
   'WalletConnect',
   '45.52 99.74 387.64 237.59',


### PR DESCRIPTION
## Summary

Add Square (rounded-rectangle background) and SquareMono variants for 5 wallet icons:

MetaMask, PhantomWallet, CoinbaseWallet, WalletConnect, RainbowWallet

TrustWallet already has Square variants. All use `0 0 64 64` viewBox with `rx="12.8"` rounded corners. Reuses existing transform constants and shared path data from Circle variants.

## Related issue

Part of #447 — wallet Square variants

## Checklist

- [x] `pnpm run check` passes
- [x] `pnpm run typecheck` passes
- [x] `pnpm test` passes
- [x] `pnpm run build` succeeds
- [x] `pnpm run size` within limits
- [x] Changeset added

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * CoinbaseWallet、MetaMask、PhantomWallet、RainbowWallet、WalletConnectのウォレットアイコンに、スクエア形状のバリエーション（通常版とモノクロ版）が追加されました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->