### PR TITLE
feat(example): infinite scroll, accessibility, search UX

### DIFF
--- a/example/src/app/layout.tsx
+++ b/example/src/app/layout.tsx
@@ -51,6 +51,12 @@ export default function RootLayout({ children }: { children: ReactNode }) {
       </head>
       <body>
         <Providers>
+          <a
+            href="#icon-grid"
+            className="fixed left-4 top-4 z-50 -translate-y-16 rounded-lg bg-accent px-4 py-2 text-sm font-medium text-white transition-transform focus:translate-y-0"
+          >
+            Skip to icons
+          </a>
           <div className="flex min-h-svh flex-col">
             <Header />
             <main className="flex-1">{children}</main>

--- a/example/src/components/elements/IconDrawer.tsx
+++ b/example/src/components/elements/IconDrawer.tsx
@@ -126,14 +126,45 @@ export default function IconDrawer({
     | ComponentType<{ className?: string; style?: React.CSSProperties }>
     | undefined;
 
-  // Close on Escape
+  // Close on Escape and focus trap
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {
-      if (e.key === 'Escape') onClose();
+      if (e.key === 'Escape') {
+        onClose();
+        return;
+      }
+      // Focus trap: cycle focus within drawer
+      if (e.key === 'Tab' && drawerRef.current) {
+        const focusable = drawerRef.current.querySelectorAll<HTMLElement>(
+          'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])',
+        );
+        if (focusable.length === 0) return;
+        const first = focusable[0];
+        const last = focusable[focusable.length - 1];
+        if (e.shiftKey && document.activeElement === first) {
+          e.preventDefault();
+          last?.focus();
+        } else if (!e.shiftKey && document.activeElement === last) {
+          e.preventDefault();
+          first?.focus();
+        }
+      }
     };
     document.addEventListener('keydown', handleKeyDown);
     return () => document.removeEventListener('keydown', handleKeyDown);
   }, [onClose]);
+
+  // Focus drawer on open and lock body scroll
+  useEffect(() => {
+    const closeBtn = drawerRef.current?.querySelector<HTMLElement>(
+      '[aria-label="Close drawer"]',
+    );
+    closeBtn?.focus();
+    document.body.style.overflow = 'hidden';
+    return () => {
+      document.body.style.overflow = '';
+    };
+  }, []);
 
   // Close on click outside
   const handleBackdropClick = useCallback(

--- a/example/src/components/elements/SearchForm.tsx
+++ b/example/src/components/elements/SearchForm.tsx
@@ -64,6 +64,7 @@ export default function SearchForm({
         id="search"
         className="peer h-11 w-full rounded-lg border border-border bg-surface pl-10 pr-12 font-mono text-sm text-white placeholder-white/30 transition-colors focus:border-accent/60 focus:ring-1 focus:ring-accent/60"
         placeholder="Search icons..."
+        aria-label={`Search icons — ${resultCount} of ${totalCount}`}
         aria-describedby="icon-count"
         value={keyword}
         onChange={e => setKeyword(e.target.value)}
@@ -83,15 +84,16 @@ export default function SearchForm({
         <circle cx={11} cy={11} r={8} />
         <path d="m21 21-4.35-4.35" />
       </svg>
-      {!keyword && (
+      {keyword ? (
+        <div className="pointer-events-none absolute right-3 flex items-center gap-2">
+          <span className="font-mono text-xs text-white/30">
+            {resultCount}/{totalCount}
+          </span>
+        </div>
+      ) : (
         <kbd className="pointer-events-none absolute right-3 rounded border border-border bg-white/5 px-1.5 py-0.5 font-mono text-xs text-white/30 transition-opacity peer-focus:opacity-0">
           /
         </kbd>
-      )}
-      {keyword && (
-        <p className="mt-1 text-sm text-white/40">
-          {resultCount} of {totalCount} icons
-        </p>
       )}
     </form>
   );

--- a/example/src/components/sections/IconTable.tsx
+++ b/example/src/components/sections/IconTable.tsx
@@ -20,6 +20,8 @@ const VARIANT_LABELS: Record<Variant, string> = {
 
 const VARIANTS: Variant[] = ['all', 'colored', 'mono'];
 
+const PAGE_SIZE = 60;
+
 export default function IconTable() {
   const [rawCategory] = useQueryState(
     'category',
@@ -34,6 +36,7 @@ export default function IconTable() {
     parseAsString.withDefault(''),
   );
   const [variant, setVariant] = useState<Variant>('all');
+  const [visibleCount, setVisibleCount] = useState(PAGE_SIZE);
 
   const validCategory = Object.hasOwn(REACT_WEB3_ICONS, rawCategory)
     ? (rawCategory as keyof typeof REACT_WEB3_ICONS)
@@ -46,6 +49,39 @@ export default function IconTable() {
     () => groupIcons(categoryIcons).length,
     [categoryIcons],
   );
+
+  // Reset visible count when the displayed results change
+  const prevResultKey = useRef('');
+  const resultKey = `${validCategory}-${keyword}-${variant}`;
+  if (resultKey !== prevResultKey.current) {
+    prevResultKey.current = resultKey;
+    if (visibleCount !== PAGE_SIZE) {
+      setVisibleCount(PAGE_SIZE);
+    }
+  }
+
+  const visibleGroups = useMemo(
+    () => displayedGroups.slice(0, visibleCount),
+    [displayedGroups, visibleCount],
+  );
+  const hasMore = visibleCount < displayedGroups.length;
+
+  // Infinite scroll: load more when sentinel enters viewport
+  const sentinelRef = useRef<HTMLDivElement>(null);
+  useEffect(() => {
+    const sentinel = sentinelRef.current;
+    if (!sentinel || !hasMore) return;
+    const observer = new IntersectionObserver(
+      entries => {
+        if (entries[0]?.isIntersecting) {
+          setVisibleCount(prev => prev + PAGE_SIZE);
+        }
+      },
+      { rootMargin: '200px' },
+    );
+    observer.observe(sentinel);
+    return () => observer.disconnect();
+  }, [hasMore]);
 
   // Find the group for the opened drawer
   const openGroup = linkedIcon
@@ -87,6 +123,7 @@ export default function IconTable() {
 
   return (
     <section
+      id="icon-grid"
       aria-label={`${validCategory} icons`}
       className="relative mb-6 px-4 pt-6 sm:px-6 lg:px-8"
     >
@@ -165,22 +202,33 @@ export default function IconTable() {
           <p className="text-sm">Try a different search term</p>
         </div>
       ) : (
-        <div
-          key={`${validCategory}-${variant}`}
-          className="mt-6 grid grid-cols-[repeat(auto-fill,minmax(88px,1fr))] gap-0 sm:grid-cols-[repeat(auto-fill,minmax(112px,1fr))]"
-        >
-          {displayedGroups.map(group => (
-            <div key={group.base} data-icon-name={group.base} className="p-2">
-              <IconCard
-                base={group.base}
-                activeVariant={group.activeVariant}
-                components={group.components}
-                highlighted={linkedIcon === group.base}
-                onClick={() => handleOpenDrawer(group.base)}
-              />
+        <>
+          <ul
+            key={`${validCategory}-${variant}`}
+            className="mt-6 grid list-none grid-cols-[repeat(auto-fill,minmax(88px,1fr))] gap-0 sm:grid-cols-[repeat(auto-fill,minmax(112px,1fr))]"
+          >
+            {visibleGroups.map(group => (
+              <li key={group.base} data-icon-name={group.base} className="p-2">
+                <IconCard
+                  base={group.base}
+                  activeVariant={group.activeVariant}
+                  components={group.components}
+                  highlighted={linkedIcon === group.base}
+                  onClick={() => handleOpenDrawer(group.base)}
+                />
+              </li>
+            ))}
+          </ul>
+          {hasMore && (
+            <div
+              ref={sentinelRef}
+              className="flex justify-center py-8"
+              aria-hidden="true"
+            >
+              <div className="h-6 w-6 animate-spin rounded-full border-2 border-white/10 border-t-accent" />
             </div>
-          ))}
-        </div>
+          )}
+        </>
       )}
 
       {/* Detail drawer */}


### PR DESCRIPTION
## Summary

- Add infinite scroll pagination using IntersectionObserver — renders 60 icons initially, loads 60 more as the user scrolls (with loading spinner sentinel)
- Add skip-to-content link (`Skip to icons`) visible on Tab focus
- Add focus trap in icon drawer (Tab cycles within drawer), auto-focus close button on open, body scroll lock while drawer is open
- Use semantic `<ul>`/`<li>` elements for icon grid instead of `role` attributes
- Improve search UX: inline result count (`42/221`) displayed inside the input field

## Related issue

Closes #511, #513, #525

## Checklist

- [x] `pnpm run check` passes
- [x] Example app builds successfully
- [x] No changeset needed (example-only changes)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * アイコングリッドに無限スクロールを導入し段階的に読み込み
  * ドロワーでTab/Shift+TabのフォーカストラップとEscでの確実な閉鎖を追加
  * 検索フォームに動的なaria-labelと表示切替（結果数表示／キーボードヒント）を導入
  * ルートレイアウトに「Skip to icons」スキップリンクを追加しアクセシビリティを向上
<!-- end of auto-generated comment: release notes by coderabbit.ai -->