### PR TITLE
fix(example): auto-apply dark color for mono icons on light background

### DIFF
--- a/example/src/components/elements/IconDrawer.tsx
+++ b/example/src/components/elements/IconDrawer.tsx
@@ -163,7 +163,7 @@ export default function IconDrawer({
       }
     });
     return () => cancelAnimationFrame(id);
-  }, [selected, previewSize, previewColor]);
+  }, [selected, previewSize, previewColor, previewBg]);
 
   // Close on Escape and focus trap
   useEffect(() => {
@@ -242,6 +242,11 @@ export default function IconDrawer({
         : svgMarkup || '(loading...)';
 
   const textColor = previewBg === 'light' ? '#666' : 'rgba(255,255,255,0.4)';
+
+  // When light BG is active and no custom color is set, use a dark color so
+  // mono icons (which rely on currentColor) remain visible against white.
+  const effectiveColor =
+    previewBg === 'light' && !previewColor ? '#1a1a1a' : previewColor;
 
   return (
     // biome-ignore lint/a11y/noStaticElementInteractions: backdrop dismisses drawer
@@ -347,8 +352,8 @@ export default function IconDrawer({
                       {VIcon && (
                         <span style={{ fontSize: previewSize }}>
                           <VIcon
-                            {...(previewColor
-                              ? { style: { color: previewColor } }
+                            {...(effectiveColor
+                              ? { style: { color: effectiveColor } }
                               : {})}
                           />
                         </span>
@@ -380,8 +385,8 @@ export default function IconDrawer({
                 {Icon && (
                   <span style={{ fontSize: previewSize }}>
                     <Icon
-                      {...(previewColor
-                        ? { style: { color: previewColor } }
+                      {...(effectiveColor
+                        ? { style: { color: effectiveColor } }
                         : {})}
                     />
                   </span>


### PR DESCRIPTION
## Summary

- When the drawer preview uses a light background and no custom color is set, mono icons (which rely on `currentColor`) are invisible against white
- This adds an `effectiveColor` derived value that falls back to `#1a1a1a` when light BG is active and no custom color is chosen
- Applied to both single preview and compare mode

## Related issue

Closes #532

## Checklist

- [x] `pnpm run check` passes
- [x] `pnpm run typecheck` passes
- [x] `pnpm test` passes
- [x] `pnpm run build` passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **バグ修正**
  * アイコンの表示色が背景モードの変更に正確に対応するよう改善しました。
  * 明るい背景でのアイコン表示の見易性を向上させました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->