### PR TITLE
fix(example): show base icon counts in category bar

### DIFF
--- a/example/src/components/sections/CategoryBar.tsx
+++ b/example/src/components/sections/CategoryBar.tsx
@@ -4,6 +4,7 @@ import Link from 'next/link';
 import { parseAsString, useQueryState } from 'nuqs';
 import { useLayoutEffect, useRef, useState } from 'react';
 
+import { groupIcons } from '../../utils/groupIcons';
 import {
   ICON_CATEGORIES,
   type IconCategory,
@@ -13,6 +14,11 @@ import {
 type Category = IconCategory;
 
 const CATEGORY_SET: ReadonlySet<string> = new Set<string>(ICON_CATEGORIES);
+
+/** Pre-computed base icon counts per category (static data, computed once) */
+const CATEGORY_COUNTS: Record<string, number> = Object.fromEntries(
+  ICON_CATEGORIES.map(cat => [cat, groupIcons(REACT_WEB3_ICONS[cat]).length]),
+);
 
 export default function CategoryBar() {
   const [rawCategory] = useQueryState(
@@ -69,7 +75,7 @@ export default function CategoryBar() {
         />
         {ICON_CATEGORIES.map(item => {
           const isActive = item === current;
-          const count = REACT_WEB3_ICONS[item].length;
+          const count = CATEGORY_COUNTS[item];
           return (
             <Link
               key={item}


### PR DESCRIPTION
## Summary

- Category bar showed total variant counts (e.g. "All 589") while the icon grid showed base icon counts ("221 icons"), creating confusion
- Now uses `groupIcons()` to pre-compute base icon counts in a static `CATEGORY_COUNTS` map
- Category bar and icon grid now show consistent numbers (e.g. "All 221", "Chain 44")

## Related issue

Closes #533

## Checklist

- [x] `pnpm run check` passes
- [x] `pnpm run typecheck` passes
- [x] `pnpm test` passes
- [x] `pnpm run build` passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **改善**
  * カテゴリバーコンポーネントのアイコン数計算処理を最適化しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->