### PR TITLE
chore: adopt develop-branch workflow

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -8,6 +8,6 @@
   "fixed": [],
   "linked": [],
   "access": "public",
-  "baseBranch": "main",
+  "baseBranch": "develop",
   "updateInternalDependencies": "patch"
 }

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,9 +1,9 @@
 name: CodeQL
 on:
   push:
-    branches: [main]
+    branches: [develop]
   pull_request:
-    branches: [main]
+    branches: [develop]
   schedule:
     - cron: '0 6 * * 1' # Weekly Monday 6 AM UTC
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,9 +1,9 @@
 name: CI
 on:
   push:
-    branches: [main]
+    branches: [develop]
   pull_request:
-    branches: [main]
+    branches: [develop]
 
 permissions:
   contents: read

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,7 +2,7 @@ name: Release
 
 on:
   push:
-    branches: [main]
+    branches: [develop]
 
 permissions:
   contents: write
@@ -20,6 +20,8 @@ jobs:
     steps:
       - name: Checkout repo
         uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
 
       - name: Install pnpm
         uses: pnpm/action-setup@v4
@@ -35,6 +37,7 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: Create release PR or publish
+        id: changesets
         uses: changesets/action@v1
         with:
           version: pnpm changeset version
@@ -45,3 +48,10 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Fast-forward main to develop
+        if: steps.changesets.outputs.published == 'true'
+        run: |
+          git checkout main
+          git merge develop --ff-only
+          git push origin main

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,5 +53,9 @@ jobs:
         if: steps.changesets.outputs.published == 'true'
         run: |
           git checkout main
-          git merge develop --ff-only
-          git push origin main
+          if git merge develop --ff-only; then
+            git push origin main
+          else
+            echo "::error::Fast-forward merge failed. main may have diverged from develop. Manual intervention required."
+            exit 1
+          fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,6 +52,7 @@ jobs:
       - name: Fast-forward main to develop
         if: steps.changesets.outputs.published == 'true'
         run: |
+          git fetch origin main:main
           git checkout main
           if git merge develop --ff-only; then
             git push origin main

--- a/.github/workflows/visual-regression.yml
+++ b/.github/workflows/visual-regression.yml
@@ -2,13 +2,13 @@ name: Visual Regression
 
 on:
   push:
-    branches: [main]
+    branches: [develop]
     paths:
       - 'src/**'
       - 'test/visual/**'
       - 'vitest.config.visual.ts'
   pull_request:
-    branches: [main]
+    branches: [develop]
     paths:
       - 'src/**'
       - 'test/visual/**'
@@ -41,31 +41,31 @@ jobs:
       - name: Install Playwright browsers
         run: pnpm exec playwright install --with-deps chromium
 
-      # On main: generate and cache reference screenshots
-      - name: Restore reference screenshots (main)
+      # On develop: generate and cache reference screenshots
+      - name: Restore reference screenshots (develop)
         if: github.event_name == 'push'
-        id: screenshots-cache-main
+        id: screenshots-cache-develop
         uses: actions/cache@v5
         with:
           path: test/visual/__screenshots__
-          key: visual-screenshots-main-${{ github.sha }}
+          key: visual-screenshots-develop-${{ github.sha }}
           restore-keys: |
-            visual-screenshots-main-
+            visual-screenshots-develop-
 
-      - name: Generate reference screenshots (main)
-        if: github.event_name == 'push' && steps.screenshots-cache-main.outputs.cache-hit != 'true'
+      - name: Generate reference screenshots (develop)
+        if: github.event_name == 'push' && steps.screenshots-cache-develop.outputs.cache-hit != 'true'
         run: pnpm test:visual:update
 
-      # On PRs: restore main baseline and compare
-      - name: Restore reference screenshots from main (PR)
+      # On PRs: restore develop baseline and compare
+      - name: Restore reference screenshots from develop (PR)
         if: github.event_name == 'pull_request'
         id: screenshots-cache-pr
         uses: actions/cache/restore@v5
         with:
           path: test/visual/__screenshots__
-          key: visual-screenshots-main-${{ github.event.pull_request.base.sha }}
+          key: visual-screenshots-develop-${{ github.event.pull_request.base.sha }}
           restore-keys: |
-            visual-screenshots-main-
+            visual-screenshots-develop-
 
       - name: Check for existing screenshots (PR)
         if: github.event_name == 'pull_request'
@@ -80,7 +80,7 @@ jobs:
       - name: Generate baseline if none cached (PR)
         if: github.event_name == 'pull_request' && steps.check-screenshots.outputs.exists != 'true'
         run: |
-          echo "::warning::No reference screenshots from main found. Generating baseline for this run."
+          echo "::warning::No reference screenshots from develop found. Generating baseline for this run."
           pnpm test:visual:update
 
       - name: Generate screenshots for new icons (PR)


### PR DESCRIPTION
## Summary

- Switch development branch from `main` to `develop`
- `main` is reserved for released code, preventing Vercel from deploying unreleased icons
- After npm publish, the release workflow fast-forwards `main` to `develop`

### Changes
- `.changeset/config.json`: baseBranch → `develop`
- `.github/workflows/release.yml`: trigger on `develop`, sync `main` after publish
- `.github/workflows/main.yml`: CI triggers on `develop`
- `.github/workflows/visual-regression.yml`: baseline branch → `develop`
- `.github/workflows/codeql.yml`: analysis branch → `develop`
- GitHub default branch changed to `develop` via API

## Related issue

Closes #541

## Checklist

- [x] CI workflows updated
- [x] Changeset baseBranch updated
- [x] Release workflow syncs main after publish
- [x] Visual regression cache keys updated
- [x] GitHub default branch set to develop

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **Chores（その他）**
  * ブランチ基準を main から develop に変更しました。
  * CodeQL、リリース、ビジュアル回帰などのCI/CDワークフローのトリガーと文言を develop に更新しました。
  * リリース処理でリポジトリ履歴の取得を改善し、Changesets によるバージョン管理ステップを追加しました。
  * リリース完了時に develop から main へ自動で fast‑forward 同期する処理を追加しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->