### PR TITLE
fix(example): category bar indicator offset and deep link scroll

### DIFF
--- a/example/.env.local.example
+++ b/example/.env.local.example
@@ -1,1 +1,0 @@
-NEXT_PUBLIC_BASE_URL="http://localhost:3000/"

--- a/example/src/components/sections/CategoryBar.tsx
+++ b/example/src/components/sections/CategoryBar.tsx
@@ -30,22 +30,24 @@ export default function CategoryBar() {
       ? (rawCategory as Category)
       : 'all';
 
-  const navRef = useRef<HTMLElement>(null);
+  const containerRef = useRef<HTMLDivElement>(null);
   const [indicator, setIndicator] = useState({ left: 0, width: 0 });
 
   // Update indicator position and scroll active tab into view when category changes.
   // useLayoutEffect prevents visual flicker on the indicator position.
   // biome-ignore lint/correctness/useExhaustiveDependencies: current drives which DOM element is active
   useLayoutEffect(() => {
-    const nav = navRef.current;
-    if (!nav) return;
-    const active = nav.querySelector<HTMLElement>('[aria-current="page"]');
+    const container = containerRef.current;
+    if (!container) return;
+    const active = container.querySelector<HTMLElement>(
+      '[aria-current="page"]',
+    );
     if (!active) return;
 
-    // Update indicator
-    const navRect = nav.getBoundingClientRect();
+    // Compute position relative to the inner container (the indicator's offset parent)
+    const containerRect = container.getBoundingClientRect();
     const rect = active.getBoundingClientRect();
-    const newLeft = rect.left - navRect.left + nav.scrollLeft;
+    const newLeft = rect.left - containerRect.left;
     const newWidth = rect.width;
     setIndicator(prev =>
       prev.left === newLeft && prev.width === newWidth
@@ -53,7 +55,7 @@ export default function CategoryBar() {
         : { left: newLeft, width: newWidth },
     );
 
-    // Scroll into view
+    // Scroll active tab into view within the scrollable nav
     active.scrollIntoView({
       behavior: 'smooth',
       block: 'nearest',
@@ -63,11 +65,10 @@ export default function CategoryBar() {
 
   return (
     <nav
-      ref={navRef}
       aria-label="Icon categories"
       className="scrollbar-none sticky top-0 z-10 overflow-x-auto border-b border-border bg-[#0a0a0a] px-4 py-2 sm:px-6"
     >
-      <div className="relative flex gap-1">
+      <div ref={containerRef} className="relative flex gap-1">
         {/* Animated indicator */}
         <div
           className="pointer-events-none absolute bottom-0 h-0.5 rounded-full bg-accent transition-all duration-200 ease-out"

--- a/example/src/components/sections/IconTable.tsx
+++ b/example/src/components/sections/IconTable.tsx
@@ -109,15 +109,13 @@ export default function IconTable() {
     return { ...group, components };
   }, [linkedIcon, allGroups]);
 
-  const hasScrolled = useRef(false);
   useEffect(() => {
-    if (!linkedIcon || hasScrolled.current) return;
+    if (!linkedIcon) return;
     const el = document.querySelector<HTMLElement>(
       `[data-icon-name="${CSS.escape(linkedIcon)}"]`,
     );
     if (el) {
       el.scrollIntoView({ behavior: 'smooth', block: 'center' });
-      hasScrolled.current = true;
     }
   }, [linkedIcon]);
 

--- a/example/src/types/env.d.ts
+++ b/example/src/types/env.d.ts
@@ -1,5 +1,0 @@
-declare namespace NodeJS {
-  interface ProcessEnv {
-    readonly NEXT_PUBLIC_BASE_URL: string;
-  }
-}


### PR DESCRIPTION
## Summary

- Fix category bar active indicator position: the indicator was shifted right by the nav's horizontal padding (`px-4`/`sm:px-6`) because position was calculated relative to the `nav` bounding rect instead of the inner container where the indicator is absolutely positioned
- Fix deep link scroll: the `hasScrolled` ref was never reset, preventing `scrollIntoView` from firing when switching between different icon deep links (`?icon=...`). The ref was unnecessary since the `useEffect` dependency array already gates execution
- Remove unused `NEXT_PUBLIC_BASE_URL` env variable declaration and example file

## Related issue

Closes #544

## Checklist

- [x] `pnpm run check` passes
- [x] `pnpm run typecheck` passes
- [x] `pnpm test` passes (4065 tests)
- [ ] No `src/` changes — changeset not required

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **バグ修正**
  * カテゴリバーのインジケーター位置の計算を改善し、スクロール時の動作を最適化
  * アイコンテーブル選択時のスクロール動作を改善

* **その他**
  * 環境設定の例から不要な設定を削除

<!-- end of auto-generated comment: release notes by coderabbit.ai -->