### PR TITLE
refactor(example): extract shared hooks, types, and icons

### DIFF
--- a/example/src/components/elements/CodeBlock.tsx
+++ b/example/src/components/elements/CodeBlock.tsx
@@ -1,24 +1,10 @@
 'use client';
 
-import { useEffect, useRef, useState } from 'react';
+import { useCopyAction } from '../../hooks/useCopyAction';
+import CopyToggleIcon from './CopyToggleIcon';
 
 export default function CodeBlock({ children }: { children: string }) {
-  const [copied, setCopied] = useState(false);
-  const timerRef = useRef<ReturnType<typeof setTimeout>>(undefined);
-
-  useEffect(() => () => clearTimeout(timerRef.current), []);
-
-  const handleCopy = () => {
-    navigator.clipboard
-      .writeText(children)
-      .then(() => {
-        setCopied(true);
-        clearTimeout(timerRef.current);
-        timerRef.current = setTimeout(() => setCopied(false), 1500);
-      })
-      // biome-ignore lint/suspicious/noConsole: clipboard error
-      .catch(console.error);
-  };
+  const { copied, copy } = useCopyAction();
 
   return (
     <div className="group relative">
@@ -27,38 +13,11 @@ export default function CodeBlock({ children }: { children: string }) {
       </pre>
       <button
         type="button"
-        onClick={handleCopy}
+        onClick={() => copy(children)}
         aria-label="Copy code"
         className="absolute right-2 top-2 rounded p-1.5 text-white/20 opacity-0 transition-all hover:bg-white/10 hover:text-white/60 focus-visible:opacity-100 group-hover:opacity-100"
       >
-        {copied ? (
-          <svg
-            viewBox="0 0 24 24"
-            fill="none"
-            stroke="currentColor"
-            strokeWidth={2.5}
-            strokeLinecap="round"
-            strokeLinejoin="round"
-            className="h-4 w-4 text-green-400"
-            aria-hidden="true"
-          >
-            <polyline points="20 6 9 17 4 12" />
-          </svg>
-        ) : (
-          <svg
-            viewBox="0 0 24 24"
-            fill="none"
-            stroke="currentColor"
-            strokeWidth={2}
-            strokeLinecap="round"
-            strokeLinejoin="round"
-            className="h-4 w-4"
-            aria-hidden="true"
-          >
-            <rect width="14" height="14" x="8" y="8" rx="2" ry="2" />
-            <path d="M4 16c-1.1 0-2-.9-2-2V4c0-1.1.9-2 2-2h10c1.1 0 2 .9 2 2" />
-          </svg>
-        )}
+        <CopyToggleIcon copied={copied} />
       </button>
     </div>
   );

--- a/example/src/components/elements/CopyToggleIcon.tsx
+++ b/example/src/components/elements/CopyToggleIcon.tsx
@@ -1,0 +1,41 @@
+/** Animated icon that toggles between a copy icon and a check mark. */
+export default function CopyToggleIcon({
+  copied,
+  className = 'h-4 w-4',
+}: {
+  copied: boolean;
+  className?: string;
+}) {
+  if (copied) {
+    return (
+      <svg
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth={2.5}
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        className={`${className} text-green-400`}
+        aria-hidden="true"
+      >
+        <polyline points="20 6 9 17 4 12" />
+      </svg>
+    );
+  }
+
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={2}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className={className}
+      aria-hidden="true"
+    >
+      <rect width="14" height="14" x="8" y="8" rx="2" ry="2" />
+      <path d="M4 16c-1.1 0-2-.9-2-2V4c0-1.1.9-2 2-2h10c1.1 0 2 .9 2 2" />
+    </svg>
+  );
+}

--- a/example/src/components/elements/CopyToggleIcon.tsx
+++ b/example/src/components/elements/CopyToggleIcon.tsx
@@ -1,4 +1,4 @@
-/** Animated icon that toggles between a copy icon and a check mark. */
+/** Icon that toggles between a copy icon and a check mark. */
 export default function CopyToggleIcon({
   copied,
   className = 'h-4 w-4',
@@ -15,7 +15,8 @@ export default function CopyToggleIcon({
         strokeWidth={2.5}
         strokeLinecap="round"
         strokeLinejoin="round"
-        className={`${className} text-green-400`}
+        className={className}
+        style={{ color: '#4ade80' }}
         aria-hidden="true"
       >
         <polyline points="20 6 9 17 4 12" />

--- a/example/src/components/elements/IconCard.tsx
+++ b/example/src/components/elements/IconCard.tsx
@@ -1,11 +1,11 @@
 'use client';
 
-import type { ComponentType } from 'react';
+import type { IconComponent } from '../../types/icons';
 
 interface Props {
   base: string;
   activeVariant: string;
-  components: Record<string, ComponentType<{ className?: string }>>;
+  components: Record<string, IconComponent>;
   highlighted?: boolean;
   onClick: () => void;
 }
@@ -17,9 +17,7 @@ export default function IconCard({
   highlighted = false,
   onClick,
 }: Props) {
-  const Icon = components[activeVariant] as
-    | ComponentType<{ className?: string }>
-    | undefined;
+  const Icon = components[activeVariant] as IconComponent | undefined;
 
   return (
     <button

--- a/example/src/components/elements/IconDrawer.tsx
+++ b/example/src/components/elements/IconDrawer.tsx
@@ -1,15 +1,16 @@
 'use client';
 
-import type { ComponentType, CSSProperties } from 'react';
+import type { CSSProperties } from 'react';
 import { useCallback, useEffect, useRef, useState } from 'react';
+
+import { useCopyAction } from '../../hooks/useCopyAction';
+import type { IconComponent } from '../../types/icons';
+import CopyToggleIcon from './CopyToggleIcon';
 
 interface Props {
   base: string;
   variants: string[];
-  components: Record<
-    string,
-    ComponentType<{ className?: string; style?: CSSProperties }>
-  >;
+  components: Record<string, IconComponent>;
   /** Current category key, or 'all' when browsing all categories */
   category: string;
   onClose: () => void;
@@ -28,28 +29,6 @@ const PRESET_COLORS = [
   { value: '#06b6d4', label: 'Cyan' },
 ] as const;
 
-/** Safely copy text and show a brief check mark. */
-function useCopyAction() {
-  const [copied, setCopied] = useState(false);
-  const timerRef = useRef<ReturnType<typeof setTimeout>>(undefined);
-
-  useEffect(() => () => clearTimeout(timerRef.current), []);
-
-  const copy = useCallback((text: string) => {
-    navigator.clipboard
-      .writeText(text)
-      .then(() => {
-        setCopied(true);
-        clearTimeout(timerRef.current);
-        timerRef.current = setTimeout(() => setCopied(false), 1500);
-      })
-      // biome-ignore lint/suspicious/noConsole: clipboard error
-      .catch(console.error);
-  }, []);
-
-  return { copied, copy };
-}
-
 function CopyButton({ text }: { text: string }) {
   const { copied, copy } = useCopyAction();
 
@@ -60,34 +39,7 @@ function CopyButton({ text }: { text: string }) {
       aria-label="Copy to clipboard"
       className="rounded p-1.5 text-white/30 transition-colors hover:bg-white/10 hover:text-white/60"
     >
-      {copied ? (
-        <svg
-          viewBox="0 0 24 24"
-          fill="none"
-          stroke="currentColor"
-          strokeWidth={2.5}
-          strokeLinecap="round"
-          strokeLinejoin="round"
-          className="h-4 w-4 text-green-400"
-          aria-hidden="true"
-        >
-          <polyline points="20 6 9 17 4 12" />
-        </svg>
-      ) : (
-        <svg
-          viewBox="0 0 24 24"
-          fill="none"
-          stroke="currentColor"
-          strokeWidth={2}
-          strokeLinecap="round"
-          strokeLinejoin="round"
-          className="h-4 w-4"
-          aria-hidden="true"
-        >
-          <rect width="14" height="14" x="8" y="8" rx="2" ry="2" />
-          <path d="M4 16c-1.1 0-2-.9-2-2V4c0-1.1.9-2 2-2h10c1.1 0 2 .9 2 2" />
-        </svg>
-      )}
+      <CopyToggleIcon copied={copied} />
     </button>
   );
 }
@@ -147,9 +99,7 @@ export default function IconDrawer({
     requestAnimationFrame(() => setOpen(true));
   }, []);
 
-  const Icon = components[selected] as
-    | ComponentType<{ className?: string; style?: CSSProperties }>
-    | undefined;
+  const Icon = components[selected] as IconComponent | undefined;
 
   // Serialize SVG after render so the code tab shows the current DOM.
   // Deps trigger re-serialization when the icon or its styling changes.
@@ -329,12 +279,7 @@ export default function IconDrawer({
               }}
             >
               {variants.map(v => {
-                const VIcon = components[v] as
-                  | ComponentType<{
-                      className?: string;
-                      style?: CSSProperties;
-                    }>
-                  | undefined;
+                const VIcon = components[v] as IconComponent | undefined;
                 return (
                   <button
                     key={v}
@@ -409,7 +354,7 @@ export default function IconDrawer({
               >
                 {variants.map(v => {
                   const VariantIcon = components[v] as
-                    | ComponentType<{ className?: string }>
+                    | IconComponent
                     | undefined;
                   const isSelected = selected === v;
                   return (

--- a/example/src/components/sections/Hero.tsx
+++ b/example/src/components/sections/Hero.tsx
@@ -1,8 +1,10 @@
 'use client';
 
-import { useEffect, useRef, useState } from 'react';
+import { useState } from 'react';
+import { useCopyAction } from '../../hooks/useCopyAction';
 import { groupIcons } from '../../utils/groupIcons';
 import { REACT_WEB3_ICONS } from '../../utils/icons';
+import CopyToggleIcon from '../elements/CopyToggleIcon';
 
 type PkgManager = 'npm' | 'yarn' | 'pnpm' | 'bun';
 
@@ -20,29 +22,11 @@ const ICON_COUNT = groupIcons(REACT_WEB3_ICONS.all).length;
 
 export default function Hero() {
   const [pkg, setPkg] = useState<PkgManager>('npm');
-  const [copied, setCopied] = useState(false);
-  const timerRef = useRef<ReturnType<typeof setTimeout>>(undefined);
+  const { copied, copy, reset } = useCopyAction();
 
-  // Clear timer on unmount
-  useEffect(() => () => clearTimeout(timerRef.current), []);
-
-  const handleCopy = () => {
-    navigator.clipboard
-      .writeText(INSTALL_CMDS[pkg])
-      .then(() => {
-        setCopied(true);
-        clearTimeout(timerRef.current);
-        timerRef.current = setTimeout(() => setCopied(false), 1500);
-      })
-      // biome-ignore lint/suspicious/noConsole: clipboard error
-      .catch(console.error);
-  };
-
-  // Reset copied when switching package manager
   const handlePkgChange = (m: PkgManager) => {
     setPkg(m);
-    setCopied(false);
-    clearTimeout(timerRef.current);
+    reset();
   };
 
   return (
@@ -63,7 +47,7 @@ export default function Hero() {
                 key={m}
                 type="button"
                 onClick={() => handlePkgChange(m)}
-                className={`rounded-md px-2.5 py-1 text-xs font-medium transition-colors ${
+                className={`rounded-md px-2.5 py-1 text-xs font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent ${
                   pkg === m
                     ? 'bg-white/10 text-white'
                     : 'text-white/30 hover:text-white/60'
@@ -75,39 +59,12 @@ export default function Hero() {
           </div>
           <button
             type="button"
-            onClick={handleCopy}
+            onClick={() => copy(INSTALL_CMDS[pkg])}
             aria-label="Copy install command"
             className="flex items-center gap-3 rounded-lg border border-border bg-surface px-5 py-2.5 font-mono text-sm text-white/80 transition-colors hover:bg-surface-hover"
           >
             <span className="select-all">{INSTALL_CMDS[pkg]}</span>
-            {copied ? (
-              <svg
-                viewBox="0 0 24 24"
-                fill="none"
-                stroke="currentColor"
-                strokeWidth={2.5}
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                className="h-4 w-4 text-green-400"
-                aria-hidden="true"
-              >
-                <polyline points="20 6 9 17 4 12" />
-              </svg>
-            ) : (
-              <svg
-                viewBox="0 0 24 24"
-                fill="none"
-                stroke="currentColor"
-                strokeWidth={2}
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                className="h-4 w-4 text-white/30"
-                aria-hidden="true"
-              >
-                <rect width="14" height="14" x="8" y="8" rx="2" ry="2" />
-                <path d="M4 16c-1.1 0-2-.9-2-2V4c0-1.1.9-2 2-2h10c1.1 0 2 .9 2 2" />
-              </svg>
-            )}
+            <CopyToggleIcon copied={copied} className="h-4 w-4 text-white/30" />
           </button>
         </div>
       </div>

--- a/example/src/components/sections/Hero.tsx
+++ b/example/src/components/sections/Hero.tsx
@@ -64,7 +64,9 @@ export default function Hero() {
             className="flex items-center gap-3 rounded-lg border border-border bg-surface px-5 py-2.5 font-mono text-sm text-white/80 transition-colors hover:bg-surface-hover"
           >
             <span className="select-all">{INSTALL_CMDS[pkg]}</span>
-            <CopyToggleIcon copied={copied} className="h-4 w-4 text-white/30" />
+            <span className="text-white/30">
+              <CopyToggleIcon copied={copied} />
+            </span>
           </button>
         </div>
       </div>

--- a/example/src/components/sections/IconTable.tsx
+++ b/example/src/components/sections/IconTable.tsx
@@ -1,20 +1,16 @@
 'use client';
 
 import { parseAsString, useQueryState } from 'nuqs';
-import type { ComponentType } from 'react';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
 import * as iconModules from 'react-web3-icons';
 import { useIconFilter } from '../../hooks/useIconFilter';
+import type { IconComponent, Variant } from '../../types/icons';
 import { groupIcons } from '../../utils/groupIcons';
 import { REACT_WEB3_ICONS } from '../../utils/icons';
 import IconCard from '../elements/IconCard';
 import IconDrawer from '../elements/IconDrawer';
 import SearchForm from '../elements/SearchForm';
-
-type IconComponent = ComponentType<{ className?: string }>;
-
-type Variant = 'all' | 'colored' | 'mono';
 
 const VARIANT_LABELS: Record<Variant, string> = {
   all: 'All',

--- a/example/src/hooks/useCopyAction.ts
+++ b/example/src/hooks/useCopyAction.ts
@@ -1,0 +1,32 @@
+'use client';
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+const COPY_FEEDBACK_MS = 1500;
+
+/** Copy text to clipboard and show brief success feedback. */
+export function useCopyAction() {
+  const [copied, setCopied] = useState(false);
+  const timerRef = useRef<ReturnType<typeof setTimeout>>(undefined);
+
+  useEffect(() => () => clearTimeout(timerRef.current), []);
+
+  const copy = useCallback((text: string) => {
+    navigator.clipboard
+      .writeText(text)
+      .then(() => {
+        setCopied(true);
+        clearTimeout(timerRef.current);
+        timerRef.current = setTimeout(() => setCopied(false), COPY_FEEDBACK_MS);
+      })
+      // biome-ignore lint/suspicious/noConsole: clipboard error
+      .catch(console.error);
+  }, []);
+
+  const reset = useCallback(() => {
+    setCopied(false);
+    clearTimeout(timerRef.current);
+  }, []);
+
+  return { copied, copy, reset };
+}

--- a/example/src/hooks/useIconFilter.ts
+++ b/example/src/hooks/useIconFilter.ts
@@ -1,11 +1,8 @@
-import type { ComponentType } from 'react';
 import { useMemo } from 'react';
 
 import * as iconModules from 'react-web3-icons';
+import type { IconComponent, Variant } from '../types/icons';
 import { groupIcons } from '../utils/groupIcons';
-
-type Variant = 'all' | 'colored' | 'mono';
-type IconComponent = ComponentType<{ className?: string }>;
 
 const icons = Object.fromEntries(
   Object.entries(iconModules).filter(

--- a/example/src/types/icons.ts
+++ b/example/src/types/icons.ts
@@ -1,0 +1,8 @@
+import type { ComponentType, CSSProperties } from 'react';
+
+export type Variant = 'all' | 'colored' | 'mono';
+
+export type IconComponent = ComponentType<{
+  className?: string;
+  style?: CSSProperties;
+}>;

--- a/package.json
+++ b/package.json
@@ -259,6 +259,11 @@
       "name": "meta",
       "path": "dist/meta/index.mjs",
       "limit": "1 KB"
+    },
+    {
+      "name": "dynamic",
+      "path": "dist/dynamic/index.mjs",
+      "limit": "90 KB"
     }
   ]
 }


### PR DESCRIPTION
## Summary

- Extract `useCopyAction` hook from IconDrawer to `hooks/useCopyAction.ts` — eliminates clipboard logic duplication across 3 components (IconDrawer, CodeBlock, Hero)
- Extract `CopyToggleIcon` component — removes verbatim copy/check SVG duplication from 3 files
- Consolidate `Variant` and `IconComponent` types to `types/icons.ts` — single source of truth, previously defined independently in useIconFilter and IconTable
- Add `dynamic` subpath to size-limit config — previously untracked
- Add `focus-visible` ring to Hero package manager buttons — accessibility fix

## Related issue

Closes #546

## Checklist

- [x] `pnpm run check` passes
- [x] `pnpm run typecheck` passes
- [x] `pnpm test` passes (4065 tests)
- [x] `pnpm run build && pnpm run size` passes
- [ ] No `src/` API changes — changeset not required

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Refactor**
  * コピー機能を再利用可能なフックとして抽出し、複数のコンポーネント間で一貫性を向上
  * アイコンコンポーネントの型定義を集約化し、コード管理を簡素化

* **Chores**
  * バンドルサイズ制限設定を更新

<!-- end of auto-generated comment: release notes by coderabbit.ai -->