### PR TITLE
fix(test): align mono variant regex with naming convention

### DIFF
--- a/test/mono.test.tsx
+++ b/test/mono.test.tsx
@@ -4,6 +4,9 @@ import ReactDOM from 'react-dom/client';
 import { describe, expect, it } from 'vitest';
 import * as icons from '../src';
 
+// All exported names (excluding non-component exports)
+const allNames = Object.keys(icons).filter(name => name !== 'IconContext');
+
 // Dynamically discover all Mono variants from exports
 const monoEntries = Object.entries(icons).filter(
   ([name]) => /Mono$/.test(name) && name !== 'IconContext',
@@ -12,6 +15,11 @@ const monoEntries = Object.entries(icons).filter(
 describe('Mono variant icons', () => {
   it('discovers at least 100 Mono variants', () => {
     expect(monoEntries.length).toBeGreaterThanOrEqual(100);
+  });
+
+  it('no Mono variants use numeric suffixes', () => {
+    const invalid = allNames.filter(n => /Mono\d+$/.test(n));
+    expect(invalid).toEqual([]);
   });
 
   it.each(

--- a/test/mono.test.tsx
+++ b/test/mono.test.tsx
@@ -6,7 +6,7 @@ import * as icons from '../src';
 
 // Dynamically discover all Mono variants from exports
 const monoEntries = Object.entries(icons).filter(
-  ([name]) => /Mono\d*$/.test(name) && name !== 'IconContext',
+  ([name]) => /Mono$/.test(name) && name !== 'IconContext',
 ) as [string, ComponentType][];
 
 describe('Mono variant icons', () => {


### PR DESCRIPTION
## Summary

- Change the mono variant filter regex in `test/mono.test.tsx` from `/Mono\d*$/` to `/Mono$/` to match the naming convention that forbids numeric suffixes on Mono variants.

## Related issue

Closes #550

## Checklist

- [x] Regex updated
- [x] All tests pass (4065 tests, 14 suites)
- [x] No changeset needed (test-only change)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Tests**
  * テスト精度の向上のため、テストフィルター条件を厳格化しました。ユーザー向けの公開機能に変更はありません。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->