### PR TITLE
docs: update branch references from main to develop

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -358,7 +358,7 @@ This project uses [Biome](https://biomejs.dev/) for linting and formatting. Run 
 
 ## Submitting a Pull Request
 
-1. Fork the repository and create a feature branch from `main`
+1. Fork the repository and create a feature branch from `develop`
 2. Make your changes and ensure all checks pass:
    ```sh
    pnpm run lint
@@ -374,4 +374,4 @@ This project uses [Biome](https://biomejs.dev/) for linting and formatting. Run 
    Follow the prompts to select the semver bump type (patch, minor, or major) and describe the change.
 
 4. Write a clear commit message (e.g., `feat(coin): add MyToken icon`)
-5. Open a pull request against `main`
+5. Open a pull request against `develop`


### PR DESCRIPTION
## Summary

Update CONTRIBUTING.md to reference `develop` instead of `main` as the base branch for feature branches and pull requests. This aligns the contributor docs with the develop-branch workflow adopted in #542.

Two references updated:
- "create a feature branch from `main`" → `develop`
- "Open a pull request against `main`" → `develop`

README.md was checked — its `main` references are GitHub permalink URLs (LICENSE, StackBlitz, image) which correctly point to the release branch; no changes needed.

## Related issue

Closes #582

## Checklist

- [x] Branch references updated in CONTRIBUTING.md
- [x] README.md reviewed (no incorrect references found)
- [x] No changeset needed (docs-only change)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **ドキュメント**
  * コントリビューション手順を更新し、プルリクエストのワークフロー内でメインブランチからデベロップブランチへの参照に変更しました。フォークおよびPR提出時の手順が更新されています。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->