### PR TITLE
fix(dynamic): warn when resolved icon export is not found

### DIFF
--- a/.changeset/dynamic-warn-missing.md
+++ b/.changeset/dynamic-warn-missing.md
@@ -1,0 +1,5 @@
+---
+'react-web3-icons': patch
+---
+
+Log a development-mode warning when a dynamic icon component resolves a name that does not exist in the category module

--- a/src/dynamic/DynamicIcon.tsx
+++ b/src/dynamic/DynamicIcon.tsx
@@ -47,7 +47,8 @@ export function createDynamicIcon<P>(
           const comp = mod[exportName] as LazyComponent | undefined;
           if (!comp) {
             if (
-              // biome-ignore lint/complexity/useLiteralKeys: TS noPropertyAccessFromIndexSignature
+              typeof process !== 'undefined' &&
+              // biome-ignore lint/complexity/useLiteralKeys: dot notation preferred for bundler DCE, but TS noPropertyAccessFromIndexSignature requires bracket access
               process.env['NODE_ENV'] !== 'production' &&
               !warnedNames.has(exportName)
             ) {

--- a/src/dynamic/DynamicIcon.tsx
+++ b/src/dynamic/DynamicIcon.tsx
@@ -12,6 +12,8 @@ import type { IconProps } from '../utils';
 type LazyComponent = ComponentType<IconProps>;
 type LazyCache = Map<string, LazyComponent>;
 
+const warnedNames: Set<string> = /* @__PURE__ */ new Set<string>();
+
 /**
  * Creates a dynamic icon component that lazily loads icons from a category module.
  *
@@ -44,6 +46,17 @@ export function createDynamicIcon<P>(
         importCategory().then(mod => {
           const comp = mod[exportName] as LazyComponent | undefined;
           if (!comp) {
+            if (
+              // biome-ignore lint/complexity/useLiteralKeys: TS noPropertyAccessFromIndexSignature
+              process.env['NODE_ENV'] !== 'production' &&
+              !warnedNames.has(exportName)
+            ) {
+              warnedNames.add(exportName);
+              // biome-ignore lint/suspicious/noConsole: intentional dev-mode warning
+              console.warn(
+                `[react-web3-icons] Icon "${exportName}" not found in module.`,
+              );
+            }
             return { default: (() => null) as unknown as LazyComponent };
           }
           return { default: comp };


### PR DESCRIPTION
## Summary

- Add a development-mode `console.warn` in `createDynamicIcon` when the resolved export name is not found in the lazy-loaded category module.
- The warning fires only once per unique missing name (tracked via a module-level `Set`), avoiding log spam.
- The warning is stripped in production builds (`process.env['NODE_ENV'] !== 'production'`).

## Related issue

Closes #548

## Checklist

- [x] `pnpm run check` — pass (only pre-existing biome schema version mismatch)
- [x] `pnpm run typecheck` — pass
- [x] `pnpm test` — 4065 tests pass
- [x] `pnpm run build` — pass
- [x] Changeset added