### PR TITLE
feat(meta): export wallet and exchange slug-to-name mappings

### DIFF
--- a/.changeset/export-wallet-exchange-slugs.md
+++ b/.changeset/export-wallet-exchange-slugs.md
@@ -1,0 +1,5 @@
+---
+'react-web3-icons': minor
+---
+
+Export WALLET_SLUG_TO_NAME and EXCHANGE_SLUG_TO_NAME from react-web3-icons/meta for runtime wallet/exchange lookups

--- a/src/dynamic/resolve.ts
+++ b/src/dynamic/resolve.ts
@@ -21,10 +21,14 @@ export function resolveChainExportName(props: {
   let baseName: string | undefined;
 
   if (props.chainId !== undefined) {
-    baseName = CHAIN_ID_TO_NAME[props.chainId as keyof typeof CHAIN_ID_TO_NAME];
+    baseName = Object.hasOwn(CHAIN_ID_TO_NAME, props.chainId)
+      ? CHAIN_ID_TO_NAME[props.chainId as keyof typeof CHAIN_ID_TO_NAME]
+      : undefined;
   } else if (props.name) {
     const slug = props.name.toLowerCase().trim();
-    baseName = CHAIN_SLUG_TO_NAME[slug as keyof typeof CHAIN_SLUG_TO_NAME];
+    baseName = Object.hasOwn(CHAIN_SLUG_TO_NAME, slug)
+      ? CHAIN_SLUG_TO_NAME[slug as keyof typeof CHAIN_SLUG_TO_NAME]
+      : undefined;
   }
 
   return baseName ? withVariant(baseName, variant) : null;
@@ -36,7 +40,9 @@ export function resolveCoinExportName(props: {
 }): string | null {
   const variant = props.variant ?? 'colored';
   const ticker = props.symbol.toUpperCase().trim();
-  const baseName = TICKER_TO_COIN[ticker as keyof typeof TICKER_TO_COIN];
+  const baseName = Object.hasOwn(TICKER_TO_COIN, ticker)
+    ? TICKER_TO_COIN[ticker as keyof typeof TICKER_TO_COIN]
+    : undefined;
   return baseName ? withVariant(baseName, variant) : null;
 }
 
@@ -46,8 +52,9 @@ export function resolveWalletExportName(props: {
 }): string | null {
   const variant = props.variant ?? 'colored';
   const slug = props.name.toLowerCase().trim();
-  const baseName =
-    WALLET_SLUG_TO_NAME[slug as keyof typeof WALLET_SLUG_TO_NAME];
+  const baseName = Object.hasOwn(WALLET_SLUG_TO_NAME, slug)
+    ? WALLET_SLUG_TO_NAME[slug as keyof typeof WALLET_SLUG_TO_NAME]
+    : undefined;
   return baseName ? withVariant(baseName, variant) : null;
 }
 
@@ -57,7 +64,8 @@ export function resolveExchangeExportName(props: {
 }): string | null {
   const variant = props.variant ?? 'colored';
   const slug = props.name.toLowerCase().trim();
-  const baseName =
-    EXCHANGE_SLUG_TO_NAME[slug as keyof typeof EXCHANGE_SLUG_TO_NAME];
+  const baseName = Object.hasOwn(EXCHANGE_SLUG_TO_NAME, slug)
+    ? EXCHANGE_SLUG_TO_NAME[slug as keyof typeof EXCHANGE_SLUG_TO_NAME]
+    : undefined;
   return baseName ? withVariant(baseName, variant) : null;
 }

--- a/src/dynamic/resolve.ts
+++ b/src/dynamic/resolve.ts
@@ -1,61 +1,16 @@
-import { CHAIN_ID_TO_NAME, CHAIN_SLUG_TO_NAME, TICKER_TO_COIN } from '../meta';
+import {
+  CHAIN_ID_TO_NAME,
+  CHAIN_SLUG_TO_NAME,
+  EXCHANGE_SLUG_TO_NAME,
+  TICKER_TO_COIN,
+  WALLET_SLUG_TO_NAME,
+} from '../meta';
 
 type Variant = 'colored' | 'mono';
 
 function withVariant(baseName: string, variant: Variant): string {
   return variant === 'mono' ? `${baseName}Mono` : baseName;
 }
-
-// Wallet slug → export base name
-const WALLET_SLUG_TO_NAME: Record<string, string> = {
-  argent: 'Argent',
-  backpackwallet: 'BackpackWallet',
-  bitgetwallet: 'BitgetWallet',
-  coinbasewallet: 'CoinbaseWallet',
-  daedaluswallet: 'DaedalusWallet',
-  enkrypt: 'Enkrypt',
-  exodus: 'Exodus',
-  imtoken: 'ImToken',
-  keplr: 'Keplr',
-  ledger: 'Ledger',
-  metamask: 'MetaMask',
-  namiwallet: 'NamiWallet',
-  okxwallet: 'OKXWallet',
-  phantomwallet: 'PhantomWallet',
-  polkadotjs: 'PolkadotJs',
-  rabby: 'Rabby',
-  rainbowwallet: 'RainbowWallet',
-  safe: 'Safe',
-  subwallet: 'SubWallet',
-  tangem: 'Tangem',
-  trezor: 'Trezor',
-  trustwallet: 'TrustWallet',
-  walletconnect: 'WalletConnect',
-  yoroiwallet: 'YoroiWallet',
-  zerion: 'Zerion',
-};
-
-// Exchange slug → export base name
-const EXCHANGE_SLUG_TO_NAME: Record<string, string> = {
-  binance: 'Binance',
-  bitfinex: 'Bitfinex',
-  bitget: 'Bitget',
-  bithumb: 'Bithumb',
-  bitstamp: 'Bitstamp',
-  bybit: 'Bybit',
-  coinbase: 'Coinbase',
-  cryptocom: 'CryptoCom',
-  deribit: 'Deribit',
-  gateio: 'Gateio',
-  gemini: 'Gemini',
-  htx: 'Htx',
-  kraken: 'Kraken',
-  kucoin: 'KuCoin',
-  mexc: 'Mexc',
-  okx: 'Okx',
-  phemex: 'Phemex',
-  upbit: 'Upbit',
-};
 
 export function resolveChainExportName(props: {
   name?: string;
@@ -91,7 +46,8 @@ export function resolveWalletExportName(props: {
 }): string | null {
   const variant = props.variant ?? 'colored';
   const slug = props.name.toLowerCase().trim();
-  const baseName = WALLET_SLUG_TO_NAME[slug];
+  const baseName =
+    WALLET_SLUG_TO_NAME[slug as keyof typeof WALLET_SLUG_TO_NAME];
   return baseName ? withVariant(baseName, variant) : null;
 }
 
@@ -101,6 +57,7 @@ export function resolveExchangeExportName(props: {
 }): string | null {
   const variant = props.variant ?? 'colored';
   const slug = props.name.toLowerCase().trim();
-  const baseName = EXCHANGE_SLUG_TO_NAME[slug];
+  const baseName =
+    EXCHANGE_SLUG_TO_NAME[slug as keyof typeof EXCHANGE_SLUG_TO_NAME];
   return baseName ? withVariant(baseName, variant) : null;
 }

--- a/src/meta/index.ts
+++ b/src/meta/index.ts
@@ -132,3 +132,86 @@ export const TICKER_TO_COIN = {
 
 /** Uppercase ticker symbol recognized by this package. */
 export type Ticker = keyof typeof TICKER_TO_COIN;
+
+/**
+ * Lowercased slug → wallet icon base name.
+ *
+ * Maps to exports from `react-web3-icons/wallet`:
+ * ```ts
+ * import { WALLET_SLUG_TO_NAME, type WalletSlug } from 'react-web3-icons/meta';
+ * import * as wallets from 'react-web3-icons/wallet';
+ *
+ * const slug = walletId.toLowerCase();
+ * const Icon = slug in WALLET_SLUG_TO_NAME
+ *   ? wallets[WALLET_SLUG_TO_NAME[slug as WalletSlug]]
+ *   : null;
+ * ```
+ */
+export const WALLET_SLUG_TO_NAME = {
+  argent: 'Argent',
+  backpackwallet: 'BackpackWallet',
+  bitgetwallet: 'BitgetWallet',
+  coinbasewallet: 'CoinbaseWallet',
+  daedaluswallet: 'DaedalusWallet',
+  enkrypt: 'Enkrypt',
+  exodus: 'Exodus',
+  imtoken: 'ImToken',
+  keplr: 'Keplr',
+  ledger: 'Ledger',
+  metamask: 'MetaMask',
+  namiwallet: 'NamiWallet',
+  okxwallet: 'OKXWallet',
+  phantomwallet: 'PhantomWallet',
+  polkadotjs: 'PolkadotJs',
+  rabby: 'Rabby',
+  rainbowwallet: 'RainbowWallet',
+  safe: 'Safe',
+  subwallet: 'SubWallet',
+  tangem: 'Tangem',
+  trezor: 'Trezor',
+  trustwallet: 'TrustWallet',
+  walletconnect: 'WalletConnect',
+  yoroiwallet: 'YoroiWallet',
+  zerion: 'Zerion',
+} as const satisfies Record<string, string>;
+
+/** Lowercased wallet slug recognized by this package. */
+export type WalletSlug = keyof typeof WALLET_SLUG_TO_NAME;
+
+/**
+ * Lowercased slug → exchange icon base name.
+ *
+ * Maps to exports from `react-web3-icons/exchange`:
+ * ```ts
+ * import { EXCHANGE_SLUG_TO_NAME, type ExchangeSlug } from 'react-web3-icons/meta';
+ * import * as exchanges from 'react-web3-icons/exchange';
+ *
+ * const slug = exchangeId.toLowerCase();
+ * const Icon = slug in EXCHANGE_SLUG_TO_NAME
+ *   ? exchanges[EXCHANGE_SLUG_TO_NAME[slug as ExchangeSlug]]
+ *   : null;
+ * ```
+ */
+export const EXCHANGE_SLUG_TO_NAME = {
+  binance: 'Binance',
+  bitfinex: 'Bitfinex',
+  bitget: 'Bitget',
+  bithumb: 'Bithumb',
+  bitstamp: 'Bitstamp',
+  bybit: 'Bybit',
+  coinbase: 'Coinbase',
+  cryptocom: 'CryptoCom',
+  deribit: 'Deribit',
+  gateio: 'Gateio',
+  gemini: 'Gemini',
+  htx: 'Htx',
+  kraken: 'Kraken',
+  kucoin: 'KuCoin',
+  mexc: 'Mexc',
+  okx: 'Okx',
+  phemex: 'Phemex',
+  upbit: 'Upbit',
+} as const satisfies Record<string, string>;
+
+/** Lowercased exchange slug recognized by this package. */
+export type ExchangeSlug = keyof typeof EXCHANGE_SLUG_TO_NAME;

--- a/src/meta/index.ts
+++ b/src/meta/index.ts
@@ -7,7 +7,7 @@
  * import * as chains from 'react-web3-icons/chain';
  *
  * // Runtime check narrows to ChainId
- * const Icon = chain.id in CHAIN_ID_TO_NAME
+ * const Icon = Object.hasOwn(CHAIN_ID_TO_NAME, chain.id)
  *   ? chains[CHAIN_ID_TO_NAME[chain.id as ChainId]]
  *   : null;
  * ```
@@ -87,7 +87,7 @@ export type ChainSlug = keyof typeof CHAIN_SLUG_TO_NAME;
  * import * as coins from 'react-web3-icons/coin';
  *
  * const symbol = token.symbol.toUpperCase();
- * const Icon = symbol in TICKER_TO_COIN
+ * const Icon = Object.hasOwn(TICKER_TO_COIN, symbol)
  *   ? coins[TICKER_TO_COIN[symbol as Ticker]]
  *   : null;
  * ```
@@ -142,7 +142,7 @@ export type Ticker = keyof typeof TICKER_TO_COIN;
  * import * as wallets from 'react-web3-icons/wallet';
  *
  * const slug = walletId.toLowerCase();
- * const Icon = slug in WALLET_SLUG_TO_NAME
+ * const Icon = Object.hasOwn(WALLET_SLUG_TO_NAME, slug)
  *   ? wallets[WALLET_SLUG_TO_NAME[slug as WalletSlug]]
  *   : null;
  * ```
@@ -187,7 +187,7 @@ export type WalletSlug = keyof typeof WALLET_SLUG_TO_NAME;
  * import * as exchanges from 'react-web3-icons/exchange';
  *
  * const slug = exchangeId.toLowerCase();
- * const Icon = slug in EXCHANGE_SLUG_TO_NAME
+ * const Icon = Object.hasOwn(EXCHANGE_SLUG_TO_NAME, slug)
  *   ? exchanges[EXCHANGE_SLUG_TO_NAME[slug as ExchangeSlug]]
  *   : null;
  * ```

--- a/test/meta.test.ts
+++ b/test/meta.test.ts
@@ -1,11 +1,15 @@
 import { describe, expect, it } from 'vitest';
 import * as chain from '../src/chain';
 import * as coin from '../src/coin';
+import * as exchange from '../src/exchange';
 import {
   CHAIN_ID_TO_NAME,
   CHAIN_SLUG_TO_NAME,
+  EXCHANGE_SLUG_TO_NAME,
   TICKER_TO_COIN,
+  WALLET_SLUG_TO_NAME,
 } from '../src/meta';
+import * as wallet from '../src/wallet';
 
 describe('CHAIN_ID_TO_NAME', () => {
   it('maps known EVM chain IDs', () => {
@@ -68,6 +72,54 @@ describe('TICKER_TO_COIN', () => {
       expect(
         coinNames.has(name),
         `TICKER_TO_COIN['${ticker}'] = '${name}' is not exported from coin`,
+      ).toBe(true);
+    }
+  });
+});
+
+describe('WALLET_SLUG_TO_NAME', () => {
+  it('maps known slugs', () => {
+    expect(WALLET_SLUG_TO_NAME.metamask).toBe('MetaMask');
+    expect(WALLET_SLUG_TO_NAME.trustwallet).toBe('TrustWallet');
+    expect(WALLET_SLUG_TO_NAME.ledger).toBe('Ledger');
+  });
+
+  it('all keys are lowercase', () => {
+    for (const slug of Object.keys(WALLET_SLUG_TO_NAME)) {
+      expect(slug).toBe(slug.toLowerCase());
+    }
+  });
+
+  it('every value references an exported wallet icon', () => {
+    const walletNames = new Set(Object.keys(wallet));
+    for (const [slug, name] of Object.entries(WALLET_SLUG_TO_NAME)) {
+      expect(
+        walletNames.has(name),
+        `WALLET_SLUG_TO_NAME['${slug}'] = '${name}' is not exported from wallet`,
+      ).toBe(true);
+    }
+  });
+});
+
+describe('EXCHANGE_SLUG_TO_NAME', () => {
+  it('maps known slugs', () => {
+    expect(EXCHANGE_SLUG_TO_NAME.binance).toBe('Binance');
+    expect(EXCHANGE_SLUG_TO_NAME.kraken).toBe('Kraken');
+    expect(EXCHANGE_SLUG_TO_NAME.coinbase).toBe('Coinbase');
+  });
+
+  it('all keys are lowercase', () => {
+    for (const slug of Object.keys(EXCHANGE_SLUG_TO_NAME)) {
+      expect(slug).toBe(slug.toLowerCase());
+    }
+  });
+
+  it('every value references an exported exchange icon', () => {
+    const exchangeNames = new Set(Object.keys(exchange));
+    for (const [slug, name] of Object.entries(EXCHANGE_SLUG_TO_NAME)) {
+      expect(
+        exchangeNames.has(name),
+        `EXCHANGE_SLUG_TO_NAME['${slug}'] = '${name}' is not exported from exchange`,
       ).toBe(true);
     }
   });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,6 +2,7 @@
   "extends": "@tsconfig/strictest/tsconfig.json",
   "compilerOptions": {
     "target": "ES2021",
+    "lib": ["ES2021", "ES2022.Object", "DOM", "DOM.Iterable"],
     "module": "ESNext",
     "moduleResolution": "Bundler",
     "jsx": "react-jsx",


### PR DESCRIPTION
## Summary

- Export `WALLET_SLUG_TO_NAME` and `EXCHANGE_SLUG_TO_NAME` (with `WalletSlug` / `ExchangeSlug` types) from `react-web3-icons/meta`
- Move the slug maps from `src/dynamic/resolve.ts` to `src/meta/index.ts` as the single source of truth; `resolve.ts` now imports them
- Add test coverage for the new exports in `test/meta.test.ts`

## Related issue

Closes #549

## Checklist

- [x] `pnpm run typecheck` passes
- [x] `pnpm test` passes (4071 tests)
- [x] `pnpm run build` passes
- [x] `pnpm run check` passes
- [x] Changeset added (minor)