### PR TITLE
feat(dynamic): add DefiIcon, DexIcon, and BridgeIcon components

### DIFF
--- a/.changeset/add-defi-dex-bridge-dynamic.md
+++ b/.changeset/add-defi-dex-bridge-dynamic.md
@@ -1,0 +1,5 @@
+---
+"react-web3-icons": minor
+---
+
+Add DefiIcon, DexIcon, and BridgeIcon dynamic components for runtime icon loading by protocol name

--- a/package.json
+++ b/package.json
@@ -258,12 +258,12 @@
     {
       "name": "meta",
       "path": "dist/meta/index.mjs",
-      "limit": "1 KB"
+      "limit": "2 KB"
     },
     {
       "name": "dynamic",
       "path": "dist/dynamic/index.mjs",
-      "limit": "90 KB"
+      "limit": "105 KB"
     }
   ]
 }

--- a/src/dynamic/index.ts
+++ b/src/dynamic/index.ts
@@ -4,8 +4,11 @@ import type { ReactNode } from 'react';
 import type { IconProps } from '../utils';
 import { createDynamicIcon } from './DynamicIcon';
 import {
+  resolveBridgeExportName,
   resolveChainExportName,
   resolveCoinExportName,
+  resolveDefiExportName,
+  resolveDexExportName,
   resolveExchangeExportName,
   resolveWalletExportName,
 } from './resolve';
@@ -41,6 +44,21 @@ export interface ExchangeIconProps extends DynamicIconBase {
   name: string;
 }
 
+export interface DefiIconProps extends DynamicIconBase {
+  /** DeFi protocol name, case-insensitive (e.g. `'aave'`, `'lido'`). */
+  name: string;
+}
+
+export interface DexIconProps extends DynamicIconBase {
+  /** DEX name, case-insensitive (e.g. `'uniswap'`, `'sushiswap'`). */
+  name: string;
+}
+
+export interface BridgeIconProps extends DynamicIconBase {
+  /** Bridge name, case-insensitive (e.g. `'layerzero'`, `'wormhole'`). */
+  name: string;
+}
+
 const CHAIN_STRIP = ['name', 'chainId', 'variant', 'fallback'] as const;
 const NAME_STRIP = ['name', 'variant', 'fallback'] as const;
 const SYMBOL_STRIP = ['symbol', 'variant', 'fallback'] as const;
@@ -70,5 +88,26 @@ export const WalletIcon = createDynamicIcon<WalletIconProps>(
 export const ExchangeIcon = createDynamicIcon<ExchangeIconProps>(
   resolveExchangeExportName,
   () => import('../exchange'),
+  NAME_STRIP,
+);
+
+/** Lazily loads a DeFi protocol icon by name. */
+export const DefiIcon = createDynamicIcon<DefiIconProps>(
+  resolveDefiExportName,
+  () => import('../defi'),
+  NAME_STRIP,
+);
+
+/** Lazily loads a DEX icon by name. */
+export const DexIcon = createDynamicIcon<DexIconProps>(
+  resolveDexExportName,
+  () => import('../dex'),
+  NAME_STRIP,
+);
+
+/** Lazily loads a bridge icon by name. */
+export const BridgeIcon = createDynamicIcon<BridgeIconProps>(
+  resolveBridgeExportName,
+  () => import('../bridge'),
   NAME_STRIP,
 );

--- a/src/dynamic/resolve.ts
+++ b/src/dynamic/resolve.ts
@@ -1,6 +1,9 @@
 import {
+  BRIDGE_SLUG_TO_NAME,
   CHAIN_ID_TO_NAME,
   CHAIN_SLUG_TO_NAME,
+  DEFI_SLUG_TO_NAME,
+  DEX_SLUG_TO_NAME,
   EXCHANGE_SLUG_TO_NAME,
   TICKER_TO_COIN,
   WALLET_SLUG_TO_NAME,
@@ -66,6 +69,42 @@ export function resolveExchangeExportName(props: {
   const slug = props.name.toLowerCase().trim();
   const baseName = Object.hasOwn(EXCHANGE_SLUG_TO_NAME, slug)
     ? EXCHANGE_SLUG_TO_NAME[slug as keyof typeof EXCHANGE_SLUG_TO_NAME]
+    : undefined;
+  return baseName ? withVariant(baseName, variant) : null;
+}
+
+export function resolveDefiExportName(props: {
+  name: string;
+  variant?: Variant;
+}): string | null {
+  const variant = props.variant ?? 'colored';
+  const slug = props.name.toLowerCase().trim();
+  const baseName = Object.hasOwn(DEFI_SLUG_TO_NAME, slug)
+    ? DEFI_SLUG_TO_NAME[slug as keyof typeof DEFI_SLUG_TO_NAME]
+    : undefined;
+  return baseName ? withVariant(baseName, variant) : null;
+}
+
+export function resolveDexExportName(props: {
+  name: string;
+  variant?: Variant;
+}): string | null {
+  const variant = props.variant ?? 'colored';
+  const slug = props.name.toLowerCase().trim();
+  const baseName = Object.hasOwn(DEX_SLUG_TO_NAME, slug)
+    ? DEX_SLUG_TO_NAME[slug as keyof typeof DEX_SLUG_TO_NAME]
+    : undefined;
+  return baseName ? withVariant(baseName, variant) : null;
+}
+
+export function resolveBridgeExportName(props: {
+  name: string;
+  variant?: Variant;
+}): string | null {
+  const variant = props.variant ?? 'colored';
+  const slug = props.name.toLowerCase().trim();
+  const baseName = Object.hasOwn(BRIDGE_SLUG_TO_NAME, slug)
+    ? BRIDGE_SLUG_TO_NAME[slug as keyof typeof BRIDGE_SLUG_TO_NAME]
     : undefined;
   return baseName ? withVariant(baseName, variant) : null;
 }

--- a/src/meta/index.ts
+++ b/src/meta/index.ts
@@ -240,3 +240,88 @@ export const EXCHANGE_SLUG_TO_NAME = {
 
 /** Lowercased exchange slug recognized by this package. */
 export type ExchangeSlug = keyof typeof EXCHANGE_SLUG_TO_NAME;
+
+/**
+ * Lowercased slug → DeFi protocol icon base name.
+ *
+ * Maps to exports from `react-web3-icons/defi`:
+ * ```ts
+ * import { DEFI_SLUG_TO_NAME } from 'react-web3-icons/meta';
+ *
+ * const name = DEFI_SLUG_TO_NAME['aave']; // 'Aave'
+ * ```
+ */
+export const DEFI_SLUG_TO_NAME = {
+  aave: 'Aave',
+  balancer: 'Balancer',
+  compound: 'Compound',
+  convex: 'Convex',
+  eigenlayer: 'EigenLayer',
+  ethena: 'Ethena',
+  frax: 'Frax',
+  gmx: 'Gmx',
+  lido: 'Lido',
+  liquity: 'Liquity',
+  makerdao: 'MakerDao',
+  morpho: 'Morpho',
+  pendle: 'Pendle',
+  rocketpool: 'RocketPool',
+  safeprotocol: 'SafeProtocol',
+  spark: 'Spark',
+  synthetix: 'Synthetix',
+  yearn: 'Yearn',
+} as const satisfies Record<string, string>;
+
+/** Lowercased DeFi protocol slug recognized by this package. */
+export type DefiSlug = keyof typeof DEFI_SLUG_TO_NAME;
+
+/**
+ * Lowercased slug → DEX icon base name.
+ *
+ * Maps to exports from `react-web3-icons/dex`:
+ * ```ts
+ * import { DEX_SLUG_TO_NAME } from 'react-web3-icons/meta';
+ *
+ * const name = DEX_SLUG_TO_NAME['uniswap']; // 'Uniswap'
+ * ```
+ */
+export const DEX_SLUG_TO_NAME = {
+  aerodrome: 'Aerodrome',
+  camelot: 'Camelot',
+  cowprotocol: 'CowProtocol',
+  dydx: 'Dydx',
+  ekubo: 'Ekubo',
+  hyperliquid: 'Hyperliquid',
+  jupiter: 'Jupiter',
+  oneinch: 'Oneinch',
+  osmosis: 'Osmosis',
+  pancakeswap: 'PancakeSwap',
+  raydium: 'Raydium',
+  sushiswap: 'SushiSwap',
+  uniswap: 'Uniswap',
+  velodrome: 'Velodrome',
+} as const satisfies Record<string, string>;
+
+/** Lowercased DEX slug recognized by this package. */
+export type DexSlug = keyof typeof DEX_SLUG_TO_NAME;
+
+/**
+ * Lowercased slug → bridge icon base name.
+ *
+ * Maps to exports from `react-web3-icons/bridge`:
+ * ```ts
+ * import { BRIDGE_SLUG_TO_NAME } from 'react-web3-icons/meta';
+ *
+ * const name = BRIDGE_SLUG_TO_NAME['layerzero']; // 'LayerZero'
+ * ```
+ */
+export const BRIDGE_SLUG_TO_NAME = {
+  across: 'Across',
+  hopprotocol: 'HopProtocol',
+  layerzero: 'LayerZero',
+  stargate: 'Stargate',
+  wormhole: 'Wormhole',
+} as const satisfies Record<string, string>;
+
+/** Lowercased bridge slug recognized by this package. */
+export type BridgeSlug = keyof typeof BRIDGE_SLUG_TO_NAME;

--- a/test/dynamic.test.ts
+++ b/test/dynamic.test.ts
@@ -1,7 +1,13 @@
 import { describe, expect, it } from 'vitest';
+import * as bridge from '../src/bridge';
+import * as defi from '../src/defi';
+import * as dex from '../src/dex';
 import {
+  resolveBridgeExportName,
   resolveChainExportName,
   resolveCoinExportName,
+  resolveDefiExportName,
+  resolveDexExportName,
   resolveExchangeExportName,
   resolveWalletExportName,
 } from '../src/dynamic/resolve';
@@ -174,6 +180,154 @@ describe('resolveExchangeExportName', () => {
       expect(
         exchangeNames.has(name as string),
         `exchange slug '${slug}' resolves to '${name}' which is not exported`,
+      ).toBe(true);
+    }
+  });
+});
+
+describe('resolveDefiExportName', () => {
+  it('resolves known protocols', () => {
+    expect(resolveDefiExportName({ name: 'aave' })).toBe('Aave');
+    expect(resolveDefiExportName({ name: 'lido' })).toBe('Lido');
+    expect(resolveDefiExportName({ name: 'eigenlayer' })).toBe('EigenLayer');
+  });
+
+  it('is case-insensitive', () => {
+    expect(resolveDefiExportName({ name: 'Aave' })).toBe('Aave');
+    expect(resolveDefiExportName({ name: 'LIDO' })).toBe('Lido');
+  });
+
+  it('resolves mono variant', () => {
+    expect(resolveDefiExportName({ name: 'aave', variant: 'mono' })).toBe(
+      'AaveMono',
+    );
+  });
+
+  it('returns null for unknown protocol', () => {
+    expect(resolveDefiExportName({ name: 'notadefi' })).toBeNull();
+  });
+
+  it('every resolved name references an exported defi icon', () => {
+    const defiNames = new Set(Object.keys(defi));
+    const slugs = [
+      'aave',
+      'balancer',
+      'compound',
+      'convex',
+      'eigenlayer',
+      'ethena',
+      'frax',
+      'gmx',
+      'lido',
+      'liquity',
+      'makerdao',
+      'morpho',
+      'pendle',
+      'rocketpool',
+      'safeprotocol',
+      'spark',
+      'synthetix',
+      'yearn',
+    ];
+    for (const slug of slugs) {
+      const name = resolveDefiExportName({ name: slug });
+      expect(name).not.toBeNull();
+      expect(
+        defiNames.has(name as string),
+        `defi slug '${slug}' resolves to '${name}' which is not exported`,
+      ).toBe(true);
+    }
+  });
+});
+
+describe('resolveDexExportName', () => {
+  it('resolves known DEXes', () => {
+    expect(resolveDexExportName({ name: 'uniswap' })).toBe('Uniswap');
+    expect(resolveDexExportName({ name: 'sushiswap' })).toBe('SushiSwap');
+    expect(resolveDexExportName({ name: 'jupiter' })).toBe('Jupiter');
+  });
+
+  it('is case-insensitive', () => {
+    expect(resolveDexExportName({ name: 'Uniswap' })).toBe('Uniswap');
+    expect(resolveDexExportName({ name: 'JUPITER' })).toBe('Jupiter');
+  });
+
+  it('resolves mono variant', () => {
+    expect(resolveDexExportName({ name: 'uniswap', variant: 'mono' })).toBe(
+      'UniswapMono',
+    );
+  });
+
+  it('returns null for unknown DEX', () => {
+    expect(resolveDexExportName({ name: 'notadex' })).toBeNull();
+  });
+
+  it('every resolved name references an exported dex icon', () => {
+    const dexNames = new Set(Object.keys(dex));
+    const slugs = [
+      'aerodrome',
+      'camelot',
+      'cowprotocol',
+      'dydx',
+      'ekubo',
+      'hyperliquid',
+      'jupiter',
+      'oneinch',
+      'osmosis',
+      'pancakeswap',
+      'raydium',
+      'sushiswap',
+      'uniswap',
+      'velodrome',
+    ];
+    for (const slug of slugs) {
+      const name = resolveDexExportName({ name: slug });
+      expect(name).not.toBeNull();
+      expect(
+        dexNames.has(name as string),
+        `dex slug '${slug}' resolves to '${name}' which is not exported`,
+      ).toBe(true);
+    }
+  });
+});
+
+describe('resolveBridgeExportName', () => {
+  it('resolves known bridges', () => {
+    expect(resolveBridgeExportName({ name: 'layerzero' })).toBe('LayerZero');
+    expect(resolveBridgeExportName({ name: 'wormhole' })).toBe('Wormhole');
+    expect(resolveBridgeExportName({ name: 'across' })).toBe('Across');
+  });
+
+  it('is case-insensitive', () => {
+    expect(resolveBridgeExportName({ name: 'LayerZero' })).toBe('LayerZero');
+    expect(resolveBridgeExportName({ name: 'WORMHOLE' })).toBe('Wormhole');
+  });
+
+  it('resolves mono variant', () => {
+    expect(
+      resolveBridgeExportName({ name: 'layerzero', variant: 'mono' }),
+    ).toBe('LayerZeroMono');
+  });
+
+  it('returns null for unknown bridge', () => {
+    expect(resolveBridgeExportName({ name: 'notabridge' })).toBeNull();
+  });
+
+  it('every resolved name references an exported bridge icon', () => {
+    const bridgeNames = new Set(Object.keys(bridge));
+    const slugs = [
+      'across',
+      'hopprotocol',
+      'layerzero',
+      'stargate',
+      'wormhole',
+    ];
+    for (const slug of slugs) {
+      const name = resolveBridgeExportName({ name: slug });
+      expect(name).not.toBeNull();
+      expect(
+        bridgeNames.has(name as string),
+        `bridge slug '${slug}' resolves to '${name}' which is not exported`,
       ).toBe(true);
     }
   });

--- a/test/meta.test.ts
+++ b/test/meta.test.ts
@@ -1,10 +1,16 @@
 import { describe, expect, it } from 'vitest';
+import * as bridge from '../src/bridge';
 import * as chain from '../src/chain';
 import * as coin from '../src/coin';
+import * as defi from '../src/defi';
+import * as dex from '../src/dex';
 import * as exchange from '../src/exchange';
 import {
+  BRIDGE_SLUG_TO_NAME,
   CHAIN_ID_TO_NAME,
   CHAIN_SLUG_TO_NAME,
+  DEFI_SLUG_TO_NAME,
+  DEX_SLUG_TO_NAME,
   EXCHANGE_SLUG_TO_NAME,
   TICKER_TO_COIN,
   WALLET_SLUG_TO_NAME,
@@ -145,6 +151,78 @@ describe('EXCHANGE_SLUG_TO_NAME', () => {
       expect(
         exchangeNames.has(name),
         `EXCHANGE_SLUG_TO_NAME['${slug}'] = '${name}' is not exported from exchange`,
+      ).toBe(true);
+    }
+  });
+});
+
+describe('DEFI_SLUG_TO_NAME', () => {
+  it('maps known slugs', () => {
+    expect(DEFI_SLUG_TO_NAME.aave).toBe('Aave');
+    expect(DEFI_SLUG_TO_NAME.lido).toBe('Lido');
+    expect(DEFI_SLUG_TO_NAME.eigenlayer).toBe('EigenLayer');
+  });
+
+  it('all keys are lowercase', () => {
+    for (const slug of Object.keys(DEFI_SLUG_TO_NAME)) {
+      expect(slug).toBe(slug.toLowerCase());
+    }
+  });
+
+  it('every value references an exported defi icon', () => {
+    const defiNames = new Set(Object.keys(defi));
+    for (const [slug, name] of Object.entries(DEFI_SLUG_TO_NAME)) {
+      expect(
+        defiNames.has(name),
+        `DEFI_SLUG_TO_NAME['${slug}'] = '${name}' is not exported from defi`,
+      ).toBe(true);
+    }
+  });
+});
+
+describe('DEX_SLUG_TO_NAME', () => {
+  it('maps known slugs', () => {
+    expect(DEX_SLUG_TO_NAME.uniswap).toBe('Uniswap');
+    expect(DEX_SLUG_TO_NAME.sushiswap).toBe('SushiSwap');
+    expect(DEX_SLUG_TO_NAME.jupiter).toBe('Jupiter');
+  });
+
+  it('all keys are lowercase', () => {
+    for (const slug of Object.keys(DEX_SLUG_TO_NAME)) {
+      expect(slug).toBe(slug.toLowerCase());
+    }
+  });
+
+  it('every value references an exported dex icon', () => {
+    const dexNames = new Set(Object.keys(dex));
+    for (const [slug, name] of Object.entries(DEX_SLUG_TO_NAME)) {
+      expect(
+        dexNames.has(name),
+        `DEX_SLUG_TO_NAME['${slug}'] = '${name}' is not exported from dex`,
+      ).toBe(true);
+    }
+  });
+});
+
+describe('BRIDGE_SLUG_TO_NAME', () => {
+  it('maps known slugs', () => {
+    expect(BRIDGE_SLUG_TO_NAME.layerzero).toBe('LayerZero');
+    expect(BRIDGE_SLUG_TO_NAME.wormhole).toBe('Wormhole');
+    expect(BRIDGE_SLUG_TO_NAME.across).toBe('Across');
+  });
+
+  it('all keys are lowercase', () => {
+    for (const slug of Object.keys(BRIDGE_SLUG_TO_NAME)) {
+      expect(slug).toBe(slug.toLowerCase());
+    }
+  });
+
+  it('every value references an exported bridge icon', () => {
+    const bridgeNames = new Set(Object.keys(bridge));
+    for (const [slug, name] of Object.entries(BRIDGE_SLUG_TO_NAME)) {
+      expect(
+        bridgeNames.has(name),
+        `BRIDGE_SLUG_TO_NAME['${slug}'] = '${name}' is not exported from bridge`,
       ).toBe(true);
     }
   });


### PR DESCRIPTION
## Summary

- Add `DefiIcon`, `DexIcon`, and `BridgeIcon` dynamic components that lazily load icons by protocol name (case-insensitive slug)
- Add `DEFI_SLUG_TO_NAME`, `DEX_SLUG_TO_NAME`, and `BRIDGE_SLUG_TO_NAME` typed maps to `react-web3-icons/meta` with `DefiSlug`, `DexSlug`, `BridgeSlug` type exports
- Add resolve functions (`resolveDefiExportName`, `resolveDexExportName`, `resolveBridgeExportName`) following the existing wallet/exchange pattern
- Increase dynamic bundle size limit from 90 KB to 105 KB to accommodate the new category imports

## Related issue

Closes #574

## Checklist

- [x] `pnpm run check` passes
- [x] `pnpm run typecheck` passes
- [x] `pnpm test` passes (4089 tests)
- [x] `pnpm run build` succeeds
- [x] `pnpm run size` passes
- [x] Tests cross-reference all slugs against actual exports
- [x] Changeset added (minor)