### PR TITLE
test(icons): add viewBox format validation

### DIFF
--- a/test/svg-quality.test.tsx
+++ b/test/svg-quality.test.tsx
@@ -53,6 +53,34 @@ describe('SVG quality checks', () => {
       ).toBeTruthy();
     });
 
+    it('viewBox is 4 space-separated numbers with positive width/height', () => {
+      const viewBox = svg?.getAttribute('viewBox');
+      if (!viewBox) {
+        return; // covered by the previous test
+      }
+      const parts = viewBox.trim().split(/\s+/);
+      expect(
+        parts.length,
+        `${_name}: viewBox "${viewBox}" must have exactly 4 values`,
+      ).toBe(4);
+      for (const part of parts) {
+        expect(
+          Number.isFinite(Number(part)),
+          `${_name}: viewBox value "${part}" is not a valid number`,
+        ).toBe(true);
+      }
+      const width = Number(parts[2]);
+      const height = Number(parts[3]);
+      expect(
+        width,
+        `${_name}: viewBox width must be positive, got ${width}`,
+      ).toBeGreaterThan(0);
+      expect(
+        height,
+        `${_name}: viewBox height must be positive, got ${height}`,
+      ).toBeGreaterThan(0);
+    });
+
     it('has no <style> tags', () => {
       const styleTags = svg?.querySelectorAll('style') ?? [];
       expect(


### PR DESCRIPTION
## Summary

- Add viewBox format validation to `test/svg-quality.test.tsx` that checks every icon component
- Validates viewBox contains exactly 4 space-separated numbers with positive width and height
- Accepts non-standard origins (e.g. Solscan `98.37 147.89 15.99 16`, ImmutableX `59.57 116.38 280 280`)

## Related issue

Closes #564

## Checklist

- [x] `pnpm run check` passes
- [x] `pnpm run typecheck` passes
- [x] `pnpm test` passes (4691 tests, 0 failures)
- [x] No changeset needed (test-only change)