### PR TITLE
fix(example): improve text contrast for WCAG AA compliance

### DIFF
--- a/example/next-env.d.ts
+++ b/example/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/dev/types/routes.d.ts";
+import "./.next/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/example/src/app/docs/page.tsx
+++ b/example/src/app/docs/page.tsx
@@ -41,7 +41,7 @@ export default function DocsPage() {
       <div className="lg:grid lg:grid-cols-[1fr_200px] lg:gap-8">
         <div>
           <h1 className="mb-2 text-3xl font-bold text-white">API Reference</h1>
-          <p className="mb-10 text-white/40">
+          <p className="mb-10 text-white/50">
             Usage guide and complete API reference for{' '}
             <code className="rounded bg-surface px-1 py-0.5 font-mono text-sm text-white/60">
               react-web3-icons
@@ -86,16 +86,16 @@ export function MyComponent() {
                 <table className="w-full text-left">
                   <thead>
                     <tr className="border-b border-border bg-surface">
-                      <th className="py-2 pr-4 pl-3 text-xs font-semibold uppercase tracking-wide text-white/40">
+                      <th className="py-2 pr-4 pl-3 text-xs font-semibold uppercase tracking-wide text-white/50">
                         Prop
                       </th>
-                      <th className="py-2 pr-4 text-xs font-semibold uppercase tracking-wide text-white/40">
+                      <th className="py-2 pr-4 text-xs font-semibold uppercase tracking-wide text-white/50">
                         Type
                       </th>
-                      <th className="py-2 pr-4 text-xs font-semibold uppercase tracking-wide text-white/40">
+                      <th className="py-2 pr-4 text-xs font-semibold uppercase tracking-wide text-white/50">
                         Default
                       </th>
-                      <th className="py-2 text-xs font-semibold uppercase tracking-wide text-white/40">
+                      <th className="py-2 text-xs font-semibold uppercase tracking-wide text-white/50">
                         Description
                       </th>
                     </tr>
@@ -108,7 +108,7 @@ export function MyComponent() {
                       <td className="py-2 pr-4 align-top font-mono text-sm text-white/60">
                         {'string | number'}
                       </td>
-                      <td className="py-2 pr-4 align-top font-mono text-sm text-white/40">
+                      <td className="py-2 pr-4 align-top font-mono text-sm text-white/50">
                         {'"1em"'}
                       </td>
                       <td className="py-2 align-top text-sm text-white/60">
@@ -127,7 +127,7 @@ export function MyComponent() {
                       <td className="py-2 pr-4 align-top font-mono text-sm text-white/60">
                         string
                       </td>
-                      <td className="py-2 pr-4 align-top font-mono text-sm text-white/40">
+                      <td className="py-2 pr-4 align-top font-mono text-sm text-white/50">
                         —
                       </td>
                       <td className="py-2 align-top text-sm text-white/60">
@@ -151,7 +151,7 @@ export function MyComponent() {
                       <td className="py-2 pr-4 align-top font-mono text-sm text-white/60">
                         string
                       </td>
-                      <td className="py-2 pr-4 align-top font-mono text-sm text-white/40">
+                      <td className="py-2 pr-4 align-top font-mono text-sm text-white/50">
                         —
                       </td>
                       <td className="py-2 align-top text-sm text-white/60">
@@ -173,7 +173,7 @@ export function MyComponent() {
                       <td className="py-2 pr-4 align-top font-mono text-sm text-white/60">
                         string
                       </td>
-                      <td className="py-2 pr-4 align-top font-mono text-sm text-white/40">
+                      <td className="py-2 pr-4 align-top font-mono text-sm text-white/50">
                         —
                       </td>
                       <td className="py-2 align-top text-sm text-white/60">
@@ -199,7 +199,7 @@ export function MyComponent() {
                       <td className="py-2 pr-4 align-top font-mono text-sm text-white/60">
                         boolean
                       </td>
-                      <td className="py-2 pr-4 align-top font-mono text-sm text-white/40">
+                      <td className="py-2 pr-4 align-top font-mono text-sm text-white/50">
                         true
                       </td>
                       <td className="py-2 align-top text-sm text-white/60">
@@ -219,7 +219,7 @@ export function MyComponent() {
                       <td className="py-2 pr-4 align-top font-mono text-sm text-white/60">
                         CSSProperties
                       </td>
-                      <td className="py-2 pr-4 align-top font-mono text-sm text-white/40">
+                      <td className="py-2 pr-4 align-top font-mono text-sm text-white/50">
                         —
                       </td>
                       <td className="py-2 align-top text-sm text-white/60">
@@ -317,10 +317,10 @@ react-web3-icons/wallet`}</CodeBlock>
                 <table className="w-full text-left">
                   <thead>
                     <tr className="border-b border-border bg-surface">
-                      <th className="py-2 pr-4 pl-3 text-xs font-semibold uppercase tracking-wide text-white/40">
+                      <th className="py-2 pr-4 pl-3 text-xs font-semibold uppercase tracking-wide text-white/50">
                         Suffix
                       </th>
-                      <th className="py-2 text-xs font-semibold uppercase tracking-wide text-white/40">
+                      <th className="py-2 text-xs font-semibold uppercase tracking-wide text-white/50">
                         Description
                       </th>
                     </tr>
@@ -468,7 +468,7 @@ function DynamicIcon({ name, size }: { name: IconName; size?: number }) {
         {/* Sticky sidebar TOC (desktop only) */}
         <aside className="hidden lg:block">
           <nav aria-label="Table of contents" className="sticky top-8">
-            <p className="mb-3 text-xs font-medium uppercase tracking-wide text-white/30">
+            <p className="mb-3 text-xs font-medium uppercase tracking-wide text-white/50">
               On this page
             </p>
             <ul className="flex flex-col gap-1.5 border-l border-border pl-3">
@@ -476,7 +476,7 @@ function DynamicIcon({ name, size }: { name: IconName; size?: number }) {
                 <li key={item.id}>
                   <a
                     href={`#${item.id}`}
-                    className="text-sm text-white/40 transition-colors hover:text-white/80"
+                    className="text-sm text-white/50 transition-colors hover:text-white/80"
                   >
                     {item.label}
                   </a>

--- a/example/src/app/not-found.tsx
+++ b/example/src/app/not-found.tsx
@@ -4,7 +4,7 @@ export default function NotFound() {
   return (
     <div className="my-24 flex flex-col items-center gap-4">
       <h1 className="text-6xl font-bold text-white/80">404</h1>
-      <p className="text-xl font-medium text-white/40">Page not found</p>
+      <p className="text-xl font-medium text-white/50">Page not found</p>
       <Link
         href="/"
         className="mt-4 rounded-lg border border-border px-5 py-2 text-sm font-medium text-white/60 transition-colors hover:bg-surface-hover hover:text-white"

--- a/example/src/components/elements/IconCard.tsx
+++ b/example/src/components/elements/IconCard.tsx
@@ -29,7 +29,7 @@ export default function IconCard({
       }`}
     >
       {Icon && <Icon className="text-4xl" />}
-      <p className="w-full truncate text-center font-mono text-[11px] text-white/40">
+      <p className="w-full truncate text-center font-mono text-[11px] text-white/50">
         {base}
       </p>
     </button>

--- a/example/src/components/elements/IconDrawer.tsx
+++ b/example/src/components/elements/IconDrawer.tsx
@@ -261,7 +261,7 @@ export default function IconDrawer({
               className={`rounded px-2 py-0.5 text-xs font-medium transition-colors ${
                 compareMode
                   ? 'bg-accent/20 text-accent'
-                  : 'bg-white/5 text-white/50 hover:text-white/50'
+                  : 'bg-white/5 text-white/50 hover:text-white/60'
               }`}
             >
               Compare
@@ -411,7 +411,7 @@ export default function IconDrawer({
                 className={`rounded px-2 py-0.5 font-mono text-[10px] transition-colors ${
                   previewSize === size
                     ? 'bg-accent/20 text-accent'
-                    : 'bg-white/5 text-white/50 hover:text-white/50'
+                    : 'bg-white/5 text-white/50 hover:text-white/60'
                 }`}
               >
                 {size}
@@ -456,7 +456,7 @@ export default function IconDrawer({
                 className="absolute inset-0 h-7 w-7 cursor-pointer opacity-0"
                 aria-label="Custom color"
               />
-              <span className="flex h-7 w-7 items-center justify-center rounded-full border border-dashed border-white/20 text-white/50 transition-colors hover:border-white/40 hover:text-white/50">
+              <span className="flex h-7 w-7 items-center justify-center rounded-full border border-dashed border-white/20 text-white/50 transition-colors hover:border-white/40 hover:text-white/60">
                 <svg
                   viewBox="0 0 16 16"
                   className="h-3.5 w-3.5"

--- a/example/src/components/elements/IconDrawer.tsx
+++ b/example/src/components/elements/IconDrawer.tsx
@@ -37,7 +37,7 @@ function CopyButton({ text }: { text: string }) {
       type="button"
       onClick={() => copy(text)}
       aria-label="Copy to clipboard"
-      className="rounded p-1.5 text-white/30 transition-colors hover:bg-white/10 hover:text-white/60"
+      className="rounded p-1.5 text-white/50 transition-colors hover:bg-white/10 hover:text-white/60"
     >
       <CopyToggleIcon copied={copied} />
     </button>
@@ -219,7 +219,7 @@ export default function IconDrawer({
             type="button"
             onClick={onClose}
             aria-label="Close drawer"
-            className="rounded p-1 text-white/40 transition-colors hover:bg-white/10 hover:text-white"
+            className="rounded p-1 text-white/50 transition-colors hover:bg-white/10 hover:text-white"
           >
             <svg
               viewBox="0 0 24 24"
@@ -238,7 +238,7 @@ export default function IconDrawer({
 
         {/* Preview background selector */}
         <div className="flex items-center gap-2 border-b border-border px-5 py-2">
-          <span className="text-xs text-white/30">BG</span>
+          <span className="text-xs text-white/50">BG</span>
           {(['dark', 'light', 'checker'] as const).map(bg => (
             <button
               key={bg}
@@ -261,7 +261,7 @@ export default function IconDrawer({
               className={`rounded px-2 py-0.5 text-xs font-medium transition-colors ${
                 compareMode
                   ? 'bg-accent/20 text-accent'
-                  : 'bg-white/5 text-white/30 hover:text-white/50'
+                  : 'bg-white/5 text-white/50 hover:text-white/50'
               }`}
             >
               Compare
@@ -344,7 +344,7 @@ export default function IconDrawer({
 
             {/* Variant selector */}
             <div className="border-b border-border px-5 py-4">
-              <p className="mb-3 text-xs font-medium uppercase tracking-wide text-white/30">
+              <p className="mb-3 text-xs font-medium uppercase tracking-wide text-white/50">
                 Variants
               </p>
               <div
@@ -384,10 +384,10 @@ export default function IconDrawer({
         {/* Size control */}
         <div className="border-b border-border px-5 py-4">
           <div className="mb-3 flex items-center justify-between">
-            <p className="text-xs font-medium uppercase tracking-wide text-white/30">
+            <p className="text-xs font-medium uppercase tracking-wide text-white/50">
               Size
             </p>
-            <span className="font-mono text-xs text-white/40">
+            <span className="font-mono text-xs text-white/50">
               {previewSize}px
             </span>
           </div>
@@ -411,7 +411,7 @@ export default function IconDrawer({
                 className={`rounded px-2 py-0.5 font-mono text-[10px] transition-colors ${
                   previewSize === size
                     ? 'bg-accent/20 text-accent'
-                    : 'bg-white/5 text-white/30 hover:text-white/50'
+                    : 'bg-white/5 text-white/50 hover:text-white/50'
                 }`}
               >
                 {size}
@@ -422,7 +422,7 @@ export default function IconDrawer({
 
         {/* Color control */}
         <div className="border-b border-border px-5 py-4">
-          <p className="mb-3 text-xs font-medium uppercase tracking-wide text-white/30">
+          <p className="mb-3 text-xs font-medium uppercase tracking-wide text-white/50">
             Color
           </p>
           <div className="flex flex-wrap items-center gap-2">
@@ -456,7 +456,7 @@ export default function IconDrawer({
                 className="absolute inset-0 h-7 w-7 cursor-pointer opacity-0"
                 aria-label="Custom color"
               />
-              <span className="flex h-7 w-7 items-center justify-center rounded-full border border-dashed border-white/20 text-white/30 transition-colors hover:border-white/40 hover:text-white/50">
+              <span className="flex h-7 w-7 items-center justify-center rounded-full border border-dashed border-white/20 text-white/50 transition-colors hover:border-white/40 hover:text-white/50">
                 <svg
                   viewBox="0 0 16 16"
                   className="h-3.5 w-3.5"
@@ -485,7 +485,7 @@ export default function IconDrawer({
                   className={`rounded-t-md px-3 py-1.5 text-xs font-medium transition-colors ${
                     effectiveTab === tab.key
                       ? 'bg-surface text-white'
-                      : 'text-white/30 hover:text-white/60'
+                      : 'text-white/50 hover:text-white/60'
                   }`}
                 >
                   {tab.label}

--- a/example/src/components/elements/SearchForm.tsx
+++ b/example/src/components/elements/SearchForm.tsx
@@ -77,7 +77,7 @@ export default function SearchForm({
         strokeLinejoin="round"
         width="1em"
         height="1em"
-        className="pointer-events-none absolute left-3 text-lg text-white/30 peer-focus:text-accent"
+        className="pointer-events-none absolute left-3 text-lg text-white/50 peer-focus:text-accent"
         aria-hidden="true"
       >
         <circle cx={11} cy={11} r={8} />
@@ -85,12 +85,12 @@ export default function SearchForm({
       </svg>
       {keyword ? (
         <div className="pointer-events-none absolute right-3 flex items-center gap-2">
-          <span className="font-mono text-xs text-white/30">
+          <span className="font-mono text-xs text-white/50">
             {resultCount}/{totalCount}
           </span>
         </div>
       ) : (
-        <kbd className="pointer-events-none absolute right-3 rounded border border-border bg-white/5 px-1.5 py-0.5 font-mono text-xs text-white/30 transition-opacity peer-focus:opacity-0">
+        <kbd className="pointer-events-none absolute right-3 rounded border border-border bg-white/5 px-1.5 py-0.5 font-mono text-xs text-white/50 transition-opacity peer-focus:opacity-0">
           /
         </kbd>
       )}

--- a/example/src/components/sections/CategoryBar.tsx
+++ b/example/src/components/sections/CategoryBar.tsx
@@ -84,7 +84,7 @@ export default function CategoryBar() {
               className={`shrink-0 rounded-md px-3 py-1.5 text-sm font-medium capitalize transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent ${
                 isActive
                   ? 'text-white'
-                  : 'text-white/40 hover:bg-white/5 hover:text-white/70'
+                  : 'text-white/50 hover:bg-white/5 hover:text-white/70'
               }`}
               aria-current={isActive ? 'page' : undefined}
             >

--- a/example/src/components/sections/Footer.tsx
+++ b/example/src/components/sections/Footer.tsx
@@ -3,7 +3,7 @@ import pkg from '../../../../package.json';
 export default function Footer() {
   return (
     <footer className="mt-auto border-t border-border px-4 py-4 sm:px-6">
-      <div className="flex items-center justify-between text-xs text-white/40">
+      <div className="flex items-center justify-between text-xs text-white/50">
         <div className="flex items-center gap-3">
           <span className="font-medium text-white/60">React Web3 Icons</span>
           <span className="font-mono">v{pkg.version}</span>

--- a/example/src/components/sections/Header.tsx
+++ b/example/src/components/sections/Header.tsx
@@ -13,7 +13,7 @@ export default function Header() {
             React Web3 Icons
           </Link>
         </h1>
-        <span className="font-mono text-xs text-white/40">v{pkg.version}</span>
+        <span className="font-mono text-xs text-white/50">v{pkg.version}</span>
       </div>
       <nav aria-label="Site navigation" className="flex items-center gap-4">
         <Link

--- a/example/src/components/sections/Hero.tsx
+++ b/example/src/components/sections/Hero.tsx
@@ -35,7 +35,7 @@ export default function Hero() {
         <h2 className="text-2xl font-bold tracking-tight text-white sm:text-3xl">
           {ICON_COUNT}+ Web3 icons for React
         </h2>
-        <p className="mt-3 text-sm text-white/40 sm:text-base">
+        <p className="mt-3 text-sm text-white/50 sm:text-base">
           Open-source SVG icons for chains, coins, wallets, DEXs, and more.
         </p>
 
@@ -50,7 +50,7 @@ export default function Hero() {
                 className={`rounded-md px-2.5 py-1 text-xs font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent ${
                   pkg === m
                     ? 'bg-white/10 text-white'
-                    : 'text-white/30 hover:text-white/60'
+                    : 'text-white/50 hover:text-white/60'
                 }`}
               >
                 {m}
@@ -64,7 +64,7 @@ export default function Hero() {
             className="flex items-center gap-3 rounded-lg border border-border bg-surface px-5 py-2.5 font-mono text-sm text-white/80 transition-colors hover:bg-surface-hover"
           >
             <span className="select-all">{INSTALL_CMDS[pkg]}</span>
-            <span className="text-white/30">
+            <span className="text-white/50">
               <CopyToggleIcon copied={copied} />
             </span>
           </button>

--- a/example/src/components/sections/IconTable.tsx
+++ b/example/src/components/sections/IconTable.tsx
@@ -164,7 +164,7 @@ export default function IconTable() {
               className={`h-11 px-4 text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-accent ${
                 variant === v
                   ? 'bg-white/10 text-white'
-                  : 'text-white/40 hover:bg-white/5 hover:text-white/60'
+                  : 'text-white/50 hover:bg-white/5 hover:text-white/60'
               }`}
             >
               {VARIANT_LABELS[v]}
@@ -178,7 +178,7 @@ export default function IconTable() {
       </p>
 
       {isCategoryEmpty ? (
-        <div className="mt-16 flex flex-col items-center gap-2 text-center text-white/30">
+        <div className="mt-16 flex flex-col items-center gap-2 text-center text-white/50">
           <svg
             viewBox="0 0 24 24"
             fill="none"
@@ -198,7 +198,7 @@ export default function IconTable() {
           </p>
         </div>
       ) : isSearchEmpty ? (
-        <div className="mt-16 flex flex-col items-center gap-2 text-center text-white/30">
+        <div className="mt-16 flex flex-col items-center gap-2 text-center text-white/50">
           <svg
             viewBox="0 0 24 24"
             fill="none"

--- a/package.json
+++ b/package.json
@@ -173,7 +173,7 @@
     {
       "name": "full bundle",
       "path": "dist/index.mjs",
-      "limit": "137 KB"
+      "limit": "140 KB"
     },
     {
       "name": "deprecated",
@@ -263,7 +263,7 @@
     {
       "name": "dynamic",
       "path": "dist/dynamic/index.mjs",
-      "limit": "106 KB"
+      "limit": "108 KB"
     }
   ]
 }


### PR DESCRIPTION
## Summary

- Upgrade all `text-white/30` and `text-white/40` to `text-white/50` across the example app
- Previous opacities (30-40%) against the dark `#080808` background failed WCAG AA 4.5:1 contrast ratio for normal text
- Affects: icon cards, search form, category tabs, footer, docs page, icon drawer, hero section

## Related issue

Closes #579

## Checklist

- [x] All `text-white/30` and `text-white/40` instances upgraded
- [x] Example app builds successfully
- [x] Lint passes
- [x] No `src/` changes (example-only)