### PR TITLE
a11y(example): add aria-live announcements for dynamic content

### DIFF
--- a/example/src/components/elements/CodeBlock.tsx
+++ b/example/src/components/elements/CodeBlock.tsx
@@ -30,6 +30,9 @@ export default function CodeBlock({
       >
         <CopyToggleIcon copied={copied} />
       </button>
+      <span aria-live="polite" className="sr-only">
+        {copied ? 'Copied to clipboard' : ''}
+      </span>
     </Wrapper>
   );
 }

--- a/example/src/components/elements/IconDrawer.tsx
+++ b/example/src/components/elements/IconDrawer.tsx
@@ -33,14 +33,19 @@ function CopyButton({ text }: { text: string }) {
   const { copied, copy } = useCopyAction();
 
   return (
-    <button
-      type="button"
-      onClick={() => copy(text)}
-      aria-label="Copy to clipboard"
-      className="flex min-h-11 min-w-11 items-center justify-center rounded text-white/50 transition-colors hover:bg-white/10 hover:text-white/60"
-    >
-      <CopyToggleIcon copied={copied} />
-    </button>
+    <>
+      <button
+        type="button"
+        onClick={() => copy(text)}
+        aria-label="Copy to clipboard"
+        className="flex min-h-11 min-w-11 items-center justify-center rounded text-white/50 transition-colors hover:bg-white/10 hover:text-white/60"
+      >
+        <CopyToggleIcon copied={copied} />
+      </button>
+      <span aria-live="polite" className="sr-only">
+        {copied ? 'Copied to clipboard' : ''}
+      </span>
+    </>
   );
 }
 

--- a/example/src/components/sections/Hero.tsx
+++ b/example/src/components/sections/Hero.tsx
@@ -68,6 +68,9 @@ export default function Hero() {
               <CopyToggleIcon copied={copied} />
             </span>
           </button>
+          <span aria-live="polite" className="sr-only">
+            {copied ? 'Copied to clipboard' : ''}
+          </span>
         </div>
       </div>
     </section>

--- a/example/src/components/sections/IconTable.tsx
+++ b/example/src/components/sections/IconTable.tsx
@@ -186,6 +186,9 @@ export default function IconTable() {
       <p id="icon-count" className="sr-only" aria-live="polite">
         {resultsText}
       </p>
+      <p className="sr-only" aria-live="polite">
+        {linkedIcon ? `${linkedIcon} icon details opened` : ''}
+      </p>
 
       {isCategoryEmpty ? (
         <div className="mt-16 flex flex-col items-center gap-2 text-center text-white/50">


### PR DESCRIPTION
## Summary
- Add `aria-live="polite"` regions in `CodeBlock` and `Hero` copy buttons to announce clipboard feedback
- Add `aria-live` region in `IconDrawer` for copy button feedback
- Add `aria-live` announcement in `IconTable` when a drawer opens

## Related issue
Closes #580

## Checklist
- [x] `aria-live` regions added to all dynamic copy/open feedback
- [x] `pnpm run check` passes
- [x] `pnpm run typecheck` passes
- [x] `pnpm test` passes
- [x] No changeset needed (example-only changes)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 新機能
* **アクセシビリティの向上**: スクリーンリーダーユーザー向けに、コピー完了時とアイコン詳細ドロワーオープン時に音声で通知する機能を複数のUI要素に追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->