### PR TITLE
docs(source): add source attribution to coin icons

### DIFF
--- a/.changeset/coin-source-attribution.md
+++ b/.changeset/coin-source-attribution.md
@@ -1,0 +1,5 @@
+---
+"react-web3-icons": patch
+---
+
+Add source attribution comments to coin icons

--- a/src/coin/Ada.tsx
+++ b/src/coin/Ada.tsx
@@ -1,3 +1,4 @@
+// Source: re-export of Cardano — see src/chain/Cardano.tsx
 export {
   Cardano as Ada,
   CardanoCircle as AdaCircle,

--- a/src/coin/Apt.tsx
+++ b/src/coin/Apt.tsx
@@ -1,1 +1,2 @@
+// Source: re-export of Aptos — see src/chain/Aptos.tsx
 export { Aptos as Apt, AptosMono as AptMono } from '../chain/Aptos';

--- a/src/coin/Arb.tsx
+++ b/src/coin/Arb.tsx
@@ -1,3 +1,4 @@
+// Source: re-export of Arbitrum — see src/chain/Arbitrum.tsx
 export {
   Arbitrum as Arb,
   ArbitrumCircle as ArbCircle,

--- a/src/coin/Avax.tsx
+++ b/src/coin/Avax.tsx
@@ -1,3 +1,4 @@
+// Source: re-export of Avalanche — see src/chain/Avalanche.tsx
 export {
   Avalanche as Avax,
   AvalancheCircle as AvaxCircle,

--- a/src/coin/Bch.tsx
+++ b/src/coin/Bch.tsx
@@ -1,3 +1,4 @@
+// Source: https://bitcoincash.org
 import { createIcon } from '../utils';
 
 export const Bch = createIcon('Bch', '0 0 24 24', () => (

--- a/src/coin/Bnb.tsx
+++ b/src/coin/Bnb.tsx
@@ -1,3 +1,4 @@
+// Source: https://bnbchain.org
 import { createIcon } from '../utils';
 
 export {

--- a/src/coin/Btc.tsx
+++ b/src/coin/Btc.tsx
@@ -1,3 +1,4 @@
+// Source: re-export of Bitcoin — see src/chain/Bitcoin.tsx
 export {
   Bitcoin as Btc,
   BitcoinCircle as BtcCircle,

--- a/src/coin/Busd.tsx
+++ b/src/coin/Busd.tsx
@@ -1,3 +1,4 @@
+// Source: https://binance.com
 import { createIcon } from '../utils';
 
 const busdContent = () => (

--- a/src/coin/Cake.tsx
+++ b/src/coin/Cake.tsx
@@ -1,3 +1,4 @@
+// Source: https://pancakeswap.finance
 import { createIcon } from '../utils';
 
 export const Cake = createIcon('Cake', '0 0 96 96', _id => (

--- a/src/coin/Cro.tsx
+++ b/src/coin/Cro.tsx
@@ -1,3 +1,4 @@
+// Source: https://crypto.com
 import { createIcon } from '../utils';
 
 export const Cro = createIcon('Cro', '0 0 24 24', () => (

--- a/src/coin/Dai.tsx
+++ b/src/coin/Dai.tsx
@@ -1,3 +1,4 @@
+// Source: https://makerdao.com
 import { createIcon } from '../utils';
 
 export const DaiCircle = createIcon('DaiCircle', '0 0 444.44 444.44', () => (

--- a/src/coin/Doge.tsx
+++ b/src/coin/Doge.tsx
@@ -1,3 +1,4 @@
+// Source: https://dogecoin.com
 import { createIcon } from '../utils';
 
 export const Doge = createIcon('Doge', '0 0 1875 1875', () => (

--- a/src/coin/Dot.tsx
+++ b/src/coin/Dot.tsx
@@ -1,1 +1,2 @@
+// Source: re-export of Polkadot — see src/chain/Polkadot.tsx
 export { Polkadot as Dot, PolkadotMono as DotMono } from '../chain/Polkadot';

--- a/src/coin/Eigen.tsx
+++ b/src/coin/Eigen.tsx
@@ -1,3 +1,4 @@
+// Source: re-export of EigenLayer — see src/defi/EigenLayer.tsx
 export {
   EigenLayer as Eigen,
   EigenLayerMono as EigenMono,

--- a/src/coin/Ena.tsx
+++ b/src/coin/Ena.tsx
@@ -1,3 +1,4 @@
+// Source: https://ethena.fi
 import { createIcon } from '../utils';
 
 const enaPath =

--- a/src/coin/Eth.tsx
+++ b/src/coin/Eth.tsx
@@ -1,3 +1,4 @@
+// Source: re-export of Ethereum — see src/chain/Ethereum.tsx
 export {
   Ethereum as Eth,
   EthereumCircle as EthCircle,

--- a/src/coin/Fet.tsx
+++ b/src/coin/Fet.tsx
@@ -1,3 +1,4 @@
+// Source: https://fetch.ai
 import { createIcon } from '../utils';
 
 const fetContent = () => (

--- a/src/coin/Ftm.tsx
+++ b/src/coin/Ftm.tsx
@@ -1,1 +1,2 @@
+// Source: re-export of Fantom — see src/chain/Fantom.tsx
 export { Fantom as Ftm, FantomMono as FtmMono } from '../chain/Fantom';

--- a/src/coin/Hbar.tsx
+++ b/src/coin/Hbar.tsx
@@ -1,3 +1,4 @@
+// Source: https://hedera.com
 import { createIcon } from '../utils';
 
 const hbarContent = () => (

--- a/src/coin/Icp.tsx
+++ b/src/coin/Icp.tsx
@@ -1,3 +1,4 @@
+// Source: https://internetcomputer.org
 import { createIcon } from '../utils';
 
 export const Icp = createIcon('Icp', '0 0 24 24', _id => (

--- a/src/coin/Inj.tsx
+++ b/src/coin/Inj.tsx
@@ -1,3 +1,4 @@
+// Source: https://injective.com
 import { createIcon } from '../utils';
 
 const injPath1 =

--- a/src/coin/Jup.tsx
+++ b/src/coin/Jup.tsx
@@ -1,1 +1,2 @@
+// Source: re-export of Jupiter — see src/dex/Jupiter.tsx
 export { Jupiter as Jup, JupiterMono as JupMono } from '../dex/Jupiter';

--- a/src/coin/Kas.tsx
+++ b/src/coin/Kas.tsx
@@ -1,3 +1,4 @@
+// Source: https://kaspa.org
 import { createIcon } from '../utils';
 
 export const Kas = createIcon('Kas', '0 0 24 24', () => (

--- a/src/coin/Ldo.tsx
+++ b/src/coin/Ldo.tsx
@@ -1,1 +1,2 @@
+// Source: re-export of Lido — see src/defi/Lido.tsx
 export { Lido as Ldo, LidoMono as LdoMono } from '../defi/Lido';

--- a/src/coin/Link.tsx
+++ b/src/coin/Link.tsx
@@ -1,3 +1,4 @@
+// Source: re-export of Chainlink — see src/devtool/Chainlink.tsx
 export {
   Chainlink as Link,
   ChainlinkMono as LinkMono,

--- a/src/coin/Looks.tsx
+++ b/src/coin/Looks.tsx
@@ -1,3 +1,4 @@
+// Source: https://looksrare.org
 import { createIcon } from '../utils';
 
 export const Looks = createIcon('Looks', '0 0 96 96', () => (

--- a/src/coin/Ltc.tsx
+++ b/src/coin/Ltc.tsx
@@ -1,3 +1,4 @@
+// Source: https://litecoin.org
 import { createIcon } from '../utils';
 
 export const Ltc = createIcon('Ltc', '0 0 82.6 82.6', () => (

--- a/src/coin/Matic.tsx
+++ b/src/coin/Matic.tsx
@@ -1,3 +1,4 @@
+// Source: re-export of Polygon (via Pol) — see src/coin/Pol.tsx and src/chain/Polygon.tsx
 import { Pol, PolCircle, PolCircleMono, PolMono } from './Pol';
 
 /** @deprecated Use `Pol` instead. */

--- a/src/coin/Mkr.tsx
+++ b/src/coin/Mkr.tsx
@@ -1,1 +1,2 @@
+// Source: re-export of MakerDao — see src/defi/MakerDao.tsx
 export { MakerDao as Mkr, MakerDaoMono as MkrMono } from '../defi/MakerDao';

--- a/src/coin/Mnt.tsx
+++ b/src/coin/Mnt.tsx
@@ -1,1 +1,2 @@
+// Source: re-export of Mantle — see src/chain/Mantle.tsx
 export { Mantle as Mnt, MantleMono as MntMono } from '../chain/Mantle';

--- a/src/coin/Near.tsx
+++ b/src/coin/Near.tsx
@@ -1,1 +1,2 @@
+// Source: re-export of Near — see src/chain/Near.tsx
 export { Near, NearMono } from '../chain/Near';

--- a/src/coin/Op.tsx
+++ b/src/coin/Op.tsx
@@ -1,3 +1,4 @@
+// Source: re-export of Optimism — see src/chain/Optimism.tsx
 export {
   Optimism as Op,
   OptimismCircle as OpCircle,

--- a/src/coin/Pepe.tsx
+++ b/src/coin/Pepe.tsx
@@ -1,3 +1,4 @@
+// Source: https://pepe.vip
 import { createIcon } from '../utils';
 
 export const Pepe = createIcon('Pepe', '0 0 24 24', () => (

--- a/src/coin/Pol.tsx
+++ b/src/coin/Pol.tsx
@@ -1,3 +1,4 @@
+// Source: re-export of Polygon — see src/chain/Polygon.tsx
 export {
   Polygon as Pol,
   PolygonCircle as PolCircle,

--- a/src/coin/Shib.tsx
+++ b/src/coin/Shib.tsx
@@ -1,3 +1,4 @@
+// Source: https://shibatoken.com
 import { createIcon } from '../utils';
 
 export const Shib = createIcon('Shib', '0.12 -0.04 641.66 649.06', () => (

--- a/src/coin/Sol.tsx
+++ b/src/coin/Sol.tsx
@@ -1,3 +1,4 @@
+// Source: re-export of Solana — see src/chain/Solana.tsx
 export {
   Solana as Sol,
   SolanaCircle as SolCircle,

--- a/src/coin/Stx.tsx
+++ b/src/coin/Stx.tsx
@@ -1,3 +1,4 @@
+// Source: https://stacks.co
 import { createIcon } from '../utils';
 
 const stxContent = () => (

--- a/src/coin/Tia.tsx
+++ b/src/coin/Tia.tsx
@@ -1,3 +1,4 @@
+// Source: https://celestia.org
 import { createIcon } from '../utils';
 
 const tiaContent = () => (

--- a/src/coin/Ton.tsx
+++ b/src/coin/Ton.tsx
@@ -1,1 +1,2 @@
+// Source: re-export of Ton — see src/chain/Ton.tsx
 export { Ton, TonMono } from '../chain/Ton';

--- a/src/coin/Trx.tsx
+++ b/src/coin/Trx.tsx
@@ -1,1 +1,2 @@
+// Source: re-export of Tron — see src/chain/Tron.tsx
 export { Tron as Trx, TronMono as TrxMono } from '../chain/Tron';

--- a/src/coin/Uni.tsx
+++ b/src/coin/Uni.tsx
@@ -1,1 +1,2 @@
+// Source: re-export of Uniswap — see src/dex/Uniswap.tsx
 export { Uniswap as Uni, UniswapMono as UniMono } from '../dex/Uniswap';

--- a/src/coin/Usdc.tsx
+++ b/src/coin/Usdc.tsx
@@ -1,3 +1,4 @@
+// Source: https://circle.com
 import { createIcon } from '../utils';
 
 const USDC_MARK =

--- a/src/coin/Usdt.tsx
+++ b/src/coin/Usdt.tsx
@@ -1,3 +1,4 @@
+// Source: https://tether.to
 import { createIcon } from '../utils';
 
 const USDT_MARK =

--- a/src/coin/Vet.tsx
+++ b/src/coin/Vet.tsx
@@ -1,3 +1,4 @@
+// Source: https://vechain.org
 import { createIcon } from '../utils';
 
 const vetPath =

--- a/src/coin/Xlm.tsx
+++ b/src/coin/Xlm.tsx
@@ -1,1 +1,2 @@
+// Source: re-export of Stellar — see src/chain/Stellar.tsx
 export { Stellar as Xlm, StellarMono as XlmMono } from '../chain/Stellar';

--- a/src/coin/Xmr.tsx
+++ b/src/coin/Xmr.tsx
@@ -1,3 +1,4 @@
+// Source: https://getmonero.org
 import { createIcon } from '../utils';
 
 export const Xmr = createIcon('Xmr', '0 0 32 32', () => (

--- a/src/coin/Xrp.tsx
+++ b/src/coin/Xrp.tsx
@@ -1,3 +1,4 @@
+// Source: https://xrpl.org
 import { createIcon } from '../utils';
 
 const xrpContent = () => (

--- a/src/coin/Zec.tsx
+++ b/src/coin/Zec.tsx
@@ -1,3 +1,4 @@
+// Source: https://z.cash
 import { createIcon } from '../utils';
 
 export const Zec = createIcon('Zec', '0 0 32 32', () => (


### PR DESCRIPTION
## Summary

- Add `// Source:` attribution comments to 48 coin icon files in `src/coin/`
- For files with their own SVG paths, documents the official brand website (e.g. `https://bitcoin.org`)
- For re-export files, documents the origin component and file path (e.g. `re-export of Bitcoin — see src/chain/Bitcoin.tsx`)
- Covers all major coins: BTC, ETH, SOL, BNB, ADA, DOGE, USDT, USDC, and 40 more

## Related issue

Closes #623 (partial — coin category)

## Checklist

- [x] No breaking changes
- [x] No new tests needed (comment-only changes)
- [x] Changeset included