### PR TITLE
docs(source): add source attribution guidelines and PR checklist

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -28,4 +28,5 @@
 - [ ] Build succeeds (`pnpm run build`)
 - [ ] Changeset included (if `src/` changed): `pnpm changeset`
 - [ ] Official icon source and usage context documented above (or N/A)
+- [ ] `// Source:` comment added or verified in each icon `.tsx` file (or N/A)
 - [ ] Default icon geometry/colors match official asset (or N/A)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -213,6 +213,27 @@ When adding a new icon, follow this workflow:
 
 Download from the project's official brand kit, GitHub repository, or press page. Always use the original vector file — never trace a raster image.
 
+### Source Attribution (Required)
+
+Every icon `.tsx` file must include a `// Source:` comment as the **first line after `import` statements**, documenting where the SVG path data originated. This survives the PR merge and makes future audits possible with `grep -r "// Source:" src/`.
+
+```tsx
+import { createIcon } from '../utils';
+
+// Source: <reference>
+
+export const MyToken = createIcon(...)
+```
+
+| Case | Example |
+| --- | --- |
+| Official SVG URL | `// Source: https://github.com/org/repo/blob/main/logo.svg` |
+| Brand asset page (no direct URL) | `// Source: https://brand.uniswap.org (official brand kit)` |
+| Third-party package (with license) | `// Source: @web3icons/react (MIT) — OSMO token SVG` |
+| App/favicon asset | `// Source: https://app.eigenlayer.xyz/logo/markLightA.svg` |
+| Hand-crafted / no public source | `// Source: hand-crafted — no public SVG; traced from https://...` |
+| Re-export (no own SVG paths) | `// Source: re-export of Bitcoin — see src/chain/Bitcoin.tsx` |
+
 ### Icon Authenticity Policy (Required)
 
 To protect icon quality and brand fidelity, all icon additions/updates must follow these rules:


### PR DESCRIPTION
## Summary

- Add **Source Attribution** section to `CONTRIBUTING.md` explaining the required `// Source:` comment format, when to use each variant (official URL, brand asset page, third-party package, hand-crafted, re-export), and that it enables `grep -r "// Source:" src/` audits
- Add `// Source:` checkbox to `.github/pull_request_template.md` so every icon PR is prompted to include attribution
- Update `CLAUDE.md` section 5.3 to require the `// Source:` comment as a mandatory step (CLAUDE.md is gitignored, updated locally)

## Related issue

Closes #623 (docs/rules portion — backfill covered by #624–#630)

## Checklist

- [ ] No breaking changes
- [ ] No new tests needed (docs-only changes)
- [ ] No changeset needed (no `src/` changes)