### PR TITLE
fix(devtool): deprecate Truffle Suite icons

### DIFF
--- a/.changeset/deprecate-truffle-suite-icons.md
+++ b/.changeset/deprecate-truffle-suite-icons.md
@@ -1,0 +1,5 @@
+---
+"react-web3-icons": patch
+---
+
+Deprecate `Ganache`, `GanacheMono`, `Truffle`, `TruffleMono`, `Drizzle`, and `DrizzleMono` — ConsenSys sunset Truffle Suite in September 2023.

--- a/src/deprecated.ts
+++ b/src/deprecated.ts
@@ -35,4 +35,11 @@ export const DEPRECATED_ICON_NAMES: ReadonlySet<string> = new Set([
   // TofuNFT marketplace shut down permanently in 2024
   'TofuNft',
   'TofuNftMono',
+  // Truffle Suite sunset by ConsenSys in September 2023
+  'Ganache',
+  'GanacheMono',
+  'Truffle',
+  'TruffleMono',
+  'Drizzle',
+  'DrizzleMono',
 ]);

--- a/src/devtool/Drizzle.tsx
+++ b/src/devtool/Drizzle.tsx
@@ -1,5 +1,6 @@
 import { createIcon } from '../utils';
 
+/** @deprecated ConsenSys sunset Truffle Suite in September 2023. */
 export const Drizzle = createIcon('Drizzle', '0 0 197.9 167.42', () => (
   <>
     <path
@@ -17,6 +18,7 @@ export const Drizzle = createIcon('Drizzle', '0 0 197.9 167.42', () => (
   </>
 ));
 
+/** @deprecated ConsenSys sunset Truffle Suite in September 2023. */
 export const DrizzleMono = createIcon(
   'DrizzleMono',
   '0 0 197.9 167.42',

--- a/src/devtool/Ganache.tsx
+++ b/src/devtool/Ganache.tsx
@@ -1,5 +1,6 @@
 import { createIcon } from '../utils';
 
+/** @deprecated ConsenSys sunset Truffle Suite in September 2023. */
 export const Ganache = createIcon('Ganache', '0 0 190.3 214', () => (
   <>
     <path
@@ -17,6 +18,7 @@ export const Ganache = createIcon('Ganache', '0 0 190.3 214', () => (
   </>
 ));
 
+/** @deprecated ConsenSys sunset Truffle Suite in September 2023. */
 export const GanacheMono = createIcon(
   'GanacheMono',
   '-4 -4 198.3 222',

--- a/src/devtool/Truffle.tsx
+++ b/src/devtool/Truffle.tsx
@@ -1,5 +1,6 @@
 import { createIcon } from '../utils';
 
+/** @deprecated ConsenSys sunset Truffle Suite in September 2023. */
 export const Truffle = createIcon('Truffle', '0 0 206.83 204.29', () => (
   <>
     <ellipse cx="103.17" cy="102.14" rx="100.96" ry="102.14" fill="#5e464d" />
@@ -14,6 +15,7 @@ export const Truffle = createIcon('Truffle', '0 0 206.83 204.29', () => (
   </>
 ));
 
+/** @deprecated ConsenSys sunset Truffle Suite in September 2023. */
 export const TruffleMono = createIcon(
   'TruffleMono',
   '0 0 206.83 204.29',


### PR DESCRIPTION
## Summary

- Add `@deprecated` JSDoc tags to `Ganache`, `GanacheMono`, `Truffle`, `TruffleMono`, `Drizzle`, and `DrizzleMono`
- Add all 6 names to `DEPRECATED_ICON_NAMES` in `src/deprecated.ts`
- ConsenSys sunset Truffle Suite in September 2023; Hardhat and Foundry have become the standard replacements

Closes #640 and supersedes #639 (the mono rendering fix becomes unnecessary once deprecated).

## Related issue

Closes #640

## Checklist

- [x] `pnpm run check` passes
- [x] `pnpm run typecheck` passes
- [x] `pnpm test` passes
- [x] Changeset added (patch)
- [ ] Breaking changes: none

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **非推奨機能**
  * 6つのアイコン（Ganache、GanacheMono、Truffle、TruffleMono、Drizzle、DrizzleMono）を非推奨に指定しました。ConsenSysがTruffle Suiteを2023年9月に終了したことに伴う変更です。

* **ドキュメント**
  * 非推奨アイコンの新しいリリース情報を追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->