### PR TITLE
docs(defi): update EigenLayer source comment

### DIFF
--- a/src/defi/EigenLayer.tsx
+++ b/src/defi/EigenLayer.tsx
@@ -1,6 +1,6 @@
 import { createIcon } from '../utils';
 
-// Paths sourced from app.eigenlayer.xyz/logo/markLightA.svg
+// Source: https://app.eigenlayer.xyz/logo/markLightA.svg (now 403; path data preserved from original retrieval)
 const markPath =
   'M150 300L150 0L0 0L0 300V600H150H225H300H375H450V450H375H300V300H375H450V150H525V0L450 0V150H375V0H303L300 0H228V75H300V300H225V450H150L150 300Z';
 


### PR DESCRIPTION
## Summary

- Update the `// Source:` comment format in `src/defi/EigenLayer.tsx` to match the project convention (`// Source: <URL>`)
- Note that the original URL (`app.eigenlayer.xyz/logo/markLightA.svg`) now returns 403, but the SVG path data was preserved from the original retrieval
- The icon rendering is unaffected

## Related issue

Closes #622

## Checklist

- [x] `pnpm run check` passes
- [x] `pnpm run typecheck` passes
- [x] `pnpm test` passes
- [ ] Changeset: not required (comment-only change, no API impact)
- [ ] Breaking changes: none