### PR TITLE
chore: add FUNDING.yml for GitHub sponsor button

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,1 @@
+github: derodero24


### PR DESCRIPTION
## Summary

- Add `.github/FUNDING.yml` with a GitHub Sponsors link for `@derodero24`, enabling the "Sponsor" button on the repository page

## Related issue

Closes #583

## Checklist

- [x] `.github/FUNDING.yml` created
- [x] No `src/` changes — no changeset needed