### PR TITLE
feat(example): add library comparison page

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -29,3 +29,4 @@
 - [ ] Changeset included (if `src/` changed): `pnpm changeset`
 - [ ] Official icon source and usage context documented above (or N/A)
 - [ ] Default icon geometry/colors match official asset (or N/A)
+- [ ] Compare page updated if library features changed (`example/src/app/compare/page.tsx`, or N/A)

--- a/example/src/app/compare/page.tsx
+++ b/example/src/app/compare/page.tsx
@@ -66,75 +66,177 @@ const TOC_ITEMS = [
   { id: 'features', label: 'Feature Matrix' },
 ] as const;
 
+// Competitors included in the feature matrix.
+// When adding a new feature to react-web3-icons, update the corresponding row
+// below. See CLAUDE.md § "Compare page maintenance" for the full checklist.
+const COMPETITORS = [
+  { key: 'web3icons', label: '@web3icons/react' },
+  { key: 'cryptocurrency-icons', label: 'cryptocurrency-icons' },
+  { key: 'ledger', label: '@ledgerhq/crypto-icons' },
+] as const;
+
+type CompetitorKey = (typeof COMPETITORS)[number]['key'];
+
 const COMPARISON_ROWS: {
   feature: string;
   ours: ReactNode;
-  theirs: ReactNode;
+  competitors: Record<CompetitorKey, ReactNode>;
   note?: string;
 }[] = [
   {
+    feature: 'React components',
+    ours: <CheckIcon />,
+    competitors: {
+      web3icons: <CheckIcon />,
+      'cryptocurrency-icons': <CrossIcon />,
+      ledger: <CheckIcon />,
+    },
+    note: 'cryptocurrency-icons is asset-only',
+  },
+  {
     feature: 'Tree-shakeable',
     ours: <CheckIcon />,
-    theirs: <CheckIcon />,
+    competitors: {
+      web3icons: <CheckIcon />,
+      'cryptocurrency-icons': <CrossIcon />,
+      ledger: <CrossIcon />,
+    },
   },
   {
     feature: 'TypeScript types',
     ours: <CheckIcon />,
-    theirs: <CheckIcon />,
+    competitors: {
+      web3icons: <CheckIcon />,
+      'cryptocurrency-icons': <CrossIcon />,
+      ledger: <CheckIcon />,
+    },
   },
   {
     feature: 'Colored variant',
     ours: <CheckIcon />,
-    theirs: <CheckIcon />,
+    competitors: {
+      web3icons: <CheckIcon />,
+      'cryptocurrency-icons': <CheckIcon />,
+      ledger: <CheckIcon />,
+    },
   },
   {
     feature: 'Mono variant',
     ours: <CheckIcon />,
-    theirs: <CheckIcon />,
+    competitors: {
+      web3icons: <CheckIcon />,
+      'cryptocurrency-icons': <CrossIcon />,
+      ledger: <CrossIcon />,
+    },
   },
   {
     feature: 'Background variant',
     ours: <CrossIcon />,
-    theirs: <CheckIcon />,
+    competitors: {
+      web3icons: <CheckIcon />,
+      'cryptocurrency-icons': <CrossIcon />,
+      ledger: <CrossIcon />,
+    },
   },
   {
     feature: 'Dynamic loading',
     ours: <CheckIcon />,
-    theirs: <CrossIcon />,
-    note: 'react-web3-icons/dynamic',
+    competitors: {
+      web3icons: <CrossIcon />,
+      'cryptocurrency-icons': <CrossIcon />,
+      ledger: <CheckIcon />,
+    },
+    note: 'Ledger fetches from CDN at runtime',
   },
   {
     feature: 'Meta maps (chain ID → name)',
     ours: <CheckIcon />,
-    theirs: <CrossIcon />,
+    competitors: {
+      web3icons: <CrossIcon />,
+      'cryptocurrency-icons': <CrossIcon />,
+      ledger: <CrossIcon />,
+    },
     note: 'react-web3-icons/meta',
   },
   {
     feature: 'JSDoc IDE hints',
     ours: <CheckIcon />,
-    theirs: <CrossIcon />,
+    competitors: {
+      web3icons: <CrossIcon />,
+      'cryptocurrency-icons': <CrossIcon />,
+      ledger: <CrossIcon />,
+    },
   },
   {
     feature: 'Category subpath imports',
     ours: <CheckIcon />,
-    theirs: <CrossIcon />,
+    competitors: {
+      web3icons: <CrossIcon />,
+      'cryptocurrency-icons': <CrossIcon />,
+      ledger: <CrossIcon />,
+    },
     note: '/chain, /coin, /wallet, …',
   },
   {
     feature: 'Raw SVG files',
     ours: <CheckIcon />,
-    theirs: <CheckIcon />,
+    competitors: {
+      web3icons: <CheckIcon />,
+      'cryptocurrency-icons': <CheckIcon />,
+      ledger: <CrossIcon />,
+    },
     note: 'dist/svg/<category>/<Name>.svg',
   },
   {
     feature: 'Figma plugin',
     ours: <CrossIcon />,
-    theirs: <CheckIcon />,
+    competitors: {
+      web3icons: <CheckIcon />,
+      'cryptocurrency-icons': <CrossIcon />,
+      ledger: <CrossIcon />,
+    },
+  },
+  {
+    feature: 'Actively maintained',
+    ours: <CheckIcon />,
+    competitors: {
+      web3icons: <CheckIcon />,
+      'cryptocurrency-icons': <CrossIcon />,
+      ledger: <CheckIcon />,
+    },
+    note: 'cryptocurrency-icons last updated 2022',
+  },
+  {
+    feature: 'React Native support',
+    ours: <CrossIcon />,
+    competitors: {
+      web3icons: <CrossIcon />,
+      'cryptocurrency-icons': <CrossIcon />,
+      ledger: <CheckIcon />,
+    },
+    note: '@ledgerhq/crypto-icons-ui',
   },
   {
     feature: 'Icon count',
     ours: <span className="text-sm text-white/70">~250</span>,
-    theirs: <span className="text-sm text-white/70">2,500+</span>,
+    competitors: {
+      web3icons: <span className="text-sm text-white/70">2,500+</span>,
+      'cryptocurrency-icons': (
+        <span className="text-sm text-white/70">~500</span>
+      ),
+      ledger: <span className="text-sm text-white/70">CDN-based</span>,
+    },
+  },
+  {
+    feature: 'npm weekly downloads',
+    ours: <span className="text-sm text-white/70">~100</span>,
+    competitors: {
+      web3icons: <span className="text-sm text-white/70">~24k</span>,
+      'cryptocurrency-icons': (
+        <span className="text-sm text-white/70">~14k</span>
+      ),
+      ledger: <span className="text-sm text-white/70">~13k</span>,
+    },
   },
 ];
 
@@ -151,21 +253,17 @@ export default function ComparePage() {
             <code className="rounded bg-surface px-1 py-0.5 font-mono text-sm text-white/60">
               react-web3-icons
             </code>{' '}
-            compares to{' '}
-            <code className="rounded bg-surface px-1 py-0.5 font-mono text-sm text-white/60">
-              @web3icons/react
-            </code>
-            , the other widely-used Web3 icon library for React.
+            compares to other Web3 / cryptocurrency icon libraries.
           </p>
 
           <div className="flex flex-col gap-10">
             {/* Overview */}
             <Section id="overview" title="Overview">
               <p className="mb-4 text-sm text-white/60">
-                Both libraries provide React SVG icon components for Web3
-                projects. They differ in scope and focus:
+                Several libraries provide cryptocurrency and Web3 icons. They
+                differ in scope, API design, and maintenance status:
               </p>
-              <ul className="mb-4 flex flex-col gap-2 text-sm text-white/60">
+              <ul className="mb-4 flex flex-col gap-3 text-sm text-white/60">
                 <li className="flex gap-2">
                   <span className="mt-0.5 shrink-0 text-accent">→</span>
                   <span>
@@ -174,8 +272,7 @@ export default function ComparePage() {
                     </strong>{' '}
                     prioritises a lean, production-ready bundle with
                     TypeScript-first ergonomics, per-category subpath imports,
-                    and utilities like dynamic loaders and chain ID maps that go
-                    beyond simple icon rendering.
+                    and utilities like dynamic loaders and chain ID maps.
                   </span>
                 </li>
                 <li className="flex gap-2">
@@ -185,8 +282,29 @@ export default function ComparePage() {
                       @web3icons/react
                     </strong>{' '}
                     offers a much larger catalogue (2,500+ icons), a raw SVG
-                    package for non-React consumers, and an accompanying Figma
-                    plugin.
+                    package for non-React consumers, and a Figma plugin.
+                  </span>
+                </li>
+                <li className="flex gap-2">
+                  <span className="mt-0.5 shrink-0 text-accent">→</span>
+                  <span>
+                    <strong className="font-medium text-white/80">
+                      cryptocurrency-icons
+                    </strong>{' '}
+                    (spothq) is a framework-agnostic SVG/PNG asset pack with
+                    ~500 coins and 2,700+ GitHub stars, but has been dormant
+                    since 2022 and provides no React components.
+                  </span>
+                </li>
+                <li className="flex gap-2">
+                  <span className="mt-0.5 shrink-0 text-accent">→</span>
+                  <span>
+                    <strong className="font-medium text-white/80">
+                      @ledgerhq/crypto-icons
+                    </strong>{' '}
+                    is a Ledger-ecosystem React component that fetches icons
+                    from their CDN at runtime with multi-tier fallback.
+                    Downloads are primarily driven by internal Ledger projects.
                   </span>
                 </li>
               </ul>
@@ -276,12 +394,7 @@ export default function ComparePage() {
             {/* API Comparison */}
             <Section id="api" title="API Comparison">
               <p className="mb-4 text-sm text-white/60">
-                Both libraries expose named React components with a{' '}
-                <code className="rounded bg-surface px-1 font-mono text-sm">
-                  size
-                </code>{' '}
-                prop and standard SVG passthrough. The main differences appear
-                when you need dynamic loading or metadata.
+                Each library takes a different approach to exposing icons:
               </p>
 
               <h3 className="mb-2 mt-6 text-sm font-semibold text-white/80">
@@ -306,12 +419,30 @@ const name = CHAIN_ID_TO_NAME[1]; // "Ethereum"`}</CodeBlock>
               <h3 className="mb-2 mt-6 text-sm font-semibold text-white/80">
                 @web3icons/react
               </h3>
-              <CodeBlock>{`// Named import
+              <CodeBlock>{`// Named import with variant prop
 import { IconEthereum } from '@web3icons/react';
 
 <IconEthereum size={32} variant="branded" />
 <IconEthereum size={32} variant="mono" />
 <IconEthereum size={32} variant="background" />`}</CodeBlock>
+
+              <h3 className="mb-2 mt-6 text-sm font-semibold text-white/80">
+                cryptocurrency-icons
+              </h3>
+              <CodeBlock>{`// Asset-only — no React components, just file paths
+import ethSvg from 'cryptocurrency-icons/svg/color/eth.svg';
+import btcPng from 'cryptocurrency-icons/128/color/btc.png';
+
+<img src={ethSvg} alt="Ethereum" width={32} height={32} />`}</CodeBlock>
+
+              <h3 className="mb-2 mt-6 text-sm font-semibold text-white/80">
+                @ledgerhq/crypto-icons
+              </h3>
+              <CodeBlock>{`// Single dynamic component — fetches from Ledger CDN
+import { CryptoIcon } from '@ledgerhq/crypto-icons';
+
+<CryptoIcon ledgerId="ethereum" size={32} />
+// Falls back to CoinGecko mapping, then letter icon`}</CodeBlock>
 
               <p className="mt-4 text-sm text-white/60">
                 Key differences:{' '}
@@ -334,7 +465,15 @@ import { IconEthereum } from '@web3icons/react';
                 <code className="rounded bg-surface px-1 font-mono text-sm">
                   variant
                 </code>{' '}
-                prop.
+                prop.{' '}
+                <code className="rounded bg-surface px-1 font-mono text-sm">
+                  cryptocurrency-icons
+                </code>{' '}
+                provides raw files only.{' '}
+                <code className="rounded bg-surface px-1 font-mono text-sm">
+                  @ledgerhq/crypto-icons
+                </code>{' '}
+                loads icons at runtime from a CDN.
               </p>
             </Section>
 
@@ -343,8 +482,7 @@ import { IconEthereum } from '@web3icons/react';
               <div className="overflow-x-auto rounded-lg border border-border">
                 <table className="w-full text-left">
                   <caption className="sr-only">
-                    Feature comparison between react-web3-icons and
-                    @web3icons/react
+                    Feature comparison across Web3 icon libraries
                   </caption>
                   <thead>
                     <tr className="border-b border-border bg-surface">
@@ -354,10 +492,15 @@ import { IconEthereum } from '@web3icons/react';
                       <th className="py-2 pr-4 text-center text-xs font-semibold uppercase tracking-wide text-white/50">
                         react-web3-icons
                       </th>
-                      <th className="py-2 pr-4 text-center text-xs font-semibold uppercase tracking-wide text-white/50">
-                        @web3icons/react
-                      </th>
-                      <th className="hidden py-2 pr-4 text-xs font-semibold uppercase tracking-wide text-white/50 sm:table-cell">
+                      {COMPETITORS.map(c => (
+                        <th
+                          key={c.key}
+                          className="py-2 pr-4 text-center text-xs font-semibold uppercase tracking-wide text-white/50"
+                        >
+                          {c.label}
+                        </th>
+                      ))}
+                      <th className="hidden py-2 pr-4 text-xs font-semibold uppercase tracking-wide text-white/50 xl:table-cell">
                         Note
                       </th>
                     </tr>
@@ -369,10 +512,12 @@ import { IconEthereum } from '@web3icons/react';
                           {row.feature}
                         </td>
                         <td className="py-2.5 pr-4 text-center">{row.ours}</td>
-                        <td className="py-2.5 pr-4 text-center">
-                          {row.theirs}
-                        </td>
-                        <td className="hidden py-2.5 pr-4 text-sm text-white/40 sm:table-cell">
+                        {COMPETITORS.map(c => (
+                          <td key={c.key} className="py-2.5 pr-4 text-center">
+                            {row.competitors[c.key]}
+                          </td>
+                        ))}
+                        <td className="hidden py-2.5 pr-4 text-sm text-white/40 xl:table-cell">
                           {row.note ?? ''}
                         </td>
                       </tr>
@@ -382,14 +527,32 @@ import { IconEthereum } from '@web3icons/react';
               </div>
 
               <p className="mt-4 text-sm text-white/40">
-                Data current as of March 2026.{' '}
+                Data current as of March 2026. Sources:{' '}
                 <a
                   href="https://github.com/0xa3k5/web3icons"
                   target="_blank"
                   rel="noopener noreferrer"
                   className="underline hover:text-white/60"
                 >
-                  @web3icons/react source
+                  @web3icons/react
+                </a>
+                ,{' '}
+                <a
+                  href="https://github.com/spothq/cryptocurrency-icons"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="underline hover:text-white/60"
+                >
+                  cryptocurrency-icons
+                </a>
+                ,{' '}
+                <a
+                  href="https://github.com/LedgerHQ/crypto-icons"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="underline hover:text-white/60"
+                >
+                  @ledgerhq/crypto-icons
                 </a>
                 .
               </p>

--- a/example/src/app/compare/page.tsx
+++ b/example/src/app/compare/page.tsx
@@ -1,0 +1,423 @@
+import type { Metadata } from 'next';
+import type { ReactNode } from 'react';
+import CodeBlock from '../../components/elements/CodeBlock';
+
+export const metadata: Metadata = {
+  title: 'Compare — React Web3 Icons',
+  description:
+    'How react-web3-icons compares to other Web3 icon libraries on bundle size, API design, and features.',
+};
+
+function Section({
+  id,
+  title,
+  children,
+}: {
+  id: string;
+  title: string;
+  children: ReactNode;
+}) {
+  return (
+    <section id={id} className="scroll-mt-8">
+      <h2 className="mb-4 text-xl font-semibold text-white">{title}</h2>
+      {children}
+    </section>
+  );
+}
+
+function CheckIcon() {
+  return (
+    <svg
+      viewBox="0 0 20 20"
+      fill="currentColor"
+      className="mx-auto h-4 w-4 text-accent"
+      aria-label="Yes"
+    >
+      <path
+        fillRule="evenodd"
+        clipRule="evenodd"
+        d="M16.707 5.293a1 1 0 0 1 0 1.414l-8 8a1 1 0 0 1-1.414 0l-4-4a1 1 0 0 1 1.414-1.414L8 12.586l7.293-7.293a1 1 0 0 1 1.414 0z"
+      />
+    </svg>
+  );
+}
+
+function CrossIcon() {
+  return (
+    <svg
+      viewBox="0 0 20 20"
+      fill="currentColor"
+      className="mx-auto h-4 w-4 text-white/30"
+      aria-label="No"
+    >
+      <path
+        fillRule="evenodd"
+        clipRule="evenodd"
+        d="M4.293 4.293a1 1 0 0 1 1.414 0L10 8.586l4.293-4.293a1 1 0 1 1 1.414 1.414L11.414 10l4.293 4.293a1 1 0 0 1-1.414 1.414L10 11.414l-4.293 4.293a1 1 0 0 1-1.414-1.414L8.586 10 4.293 5.707a1 1 0 0 1 0-1.414z"
+      />
+    </svg>
+  );
+}
+
+const TOC_ITEMS = [
+  { id: 'overview', label: 'Overview' },
+  { id: 'bundle-size', label: 'Bundle Size' },
+  { id: 'api', label: 'API Comparison' },
+  { id: 'features', label: 'Feature Matrix' },
+] as const;
+
+const COMPARISON_ROWS: {
+  feature: string;
+  ours: ReactNode;
+  theirs: ReactNode;
+  note?: string;
+}[] = [
+  {
+    feature: 'Tree-shakeable',
+    ours: <CheckIcon />,
+    theirs: <CheckIcon />,
+  },
+  {
+    feature: 'TypeScript types',
+    ours: <CheckIcon />,
+    theirs: <CheckIcon />,
+  },
+  {
+    feature: 'Colored variant',
+    ours: <CheckIcon />,
+    theirs: <CheckIcon />,
+  },
+  {
+    feature: 'Mono variant',
+    ours: <CheckIcon />,
+    theirs: <CheckIcon />,
+  },
+  {
+    feature: 'Background variant',
+    ours: <CrossIcon />,
+    theirs: <CheckIcon />,
+  },
+  {
+    feature: 'Dynamic loading',
+    ours: <CheckIcon />,
+    theirs: <CrossIcon />,
+    note: 'react-web3-icons/dynamic',
+  },
+  {
+    feature: 'Meta maps (chain ID → name)',
+    ours: <CheckIcon />,
+    theirs: <CrossIcon />,
+    note: 'react-web3-icons/meta',
+  },
+  {
+    feature: 'JSDoc IDE hints',
+    ours: <CheckIcon />,
+    theirs: <CrossIcon />,
+  },
+  {
+    feature: 'Category subpath imports',
+    ours: <CheckIcon />,
+    theirs: <CrossIcon />,
+    note: '/chain, /coin, /wallet, …',
+  },
+  {
+    feature: 'Raw SVG files',
+    ours: <CrossIcon />,
+    theirs: <CheckIcon />,
+    note: '@web3icons/core package',
+  },
+  {
+    feature: 'Figma plugin',
+    ours: <CrossIcon />,
+    theirs: <CheckIcon />,
+  },
+  {
+    feature: 'Icon count',
+    ours: <span className="text-sm text-white/70">~250</span>,
+    theirs: <span className="text-sm text-white/70">2,500+</span>,
+  },
+];
+
+export default function ComparePage() {
+  return (
+    <div className="mx-auto max-w-5xl px-4 py-8 sm:px-6 lg:px-8">
+      <div className="lg:grid lg:grid-cols-[1fr_200px] lg:gap-8">
+        <div>
+          <h1 className="mb-2 text-3xl font-bold text-white">
+            Library Comparison
+          </h1>
+          <p className="mb-10 text-white/50">
+            How{' '}
+            <code className="rounded bg-surface px-1 py-0.5 font-mono text-sm text-white/60">
+              react-web3-icons
+            </code>{' '}
+            compares to{' '}
+            <code className="rounded bg-surface px-1 py-0.5 font-mono text-sm text-white/60">
+              @web3icons/react
+            </code>
+            , the other widely-used Web3 icon library for React.
+          </p>
+
+          <div className="flex flex-col gap-10">
+            {/* Overview */}
+            <Section id="overview" title="Overview">
+              <p className="mb-4 text-sm text-white/60">
+                Both libraries provide React SVG icon components for Web3
+                projects. They differ in scope and focus:
+              </p>
+              <ul className="mb-4 flex flex-col gap-2 text-sm text-white/60">
+                <li className="flex gap-2">
+                  <span className="mt-0.5 shrink-0 text-accent">→</span>
+                  <span>
+                    <strong className="font-medium text-white/80">
+                      react-web3-icons
+                    </strong>{' '}
+                    prioritises a lean, production-ready bundle with
+                    TypeScript-first ergonomics, per-category subpath imports,
+                    and utilities like dynamic loaders and chain ID maps that go
+                    beyond simple icon rendering.
+                  </span>
+                </li>
+                <li className="flex gap-2">
+                  <span className="mt-0.5 shrink-0 text-accent">→</span>
+                  <span>
+                    <strong className="font-medium text-white/80">
+                      @web3icons/react
+                    </strong>{' '}
+                    offers a much larger catalogue (2,500+ icons), a raw SVG
+                    package for non-React consumers, and an accompanying Figma
+                    plugin.
+                  </span>
+                </li>
+              </ul>
+            </Section>
+
+            {/* Bundle Size */}
+            <Section id="bundle-size" title="Bundle Size">
+              <p className="mb-4 text-sm text-white/60">
+                Because both libraries ship ES modules, your bundler tree-shakes
+                unused icons automatically. The numbers below reflect
+                gzip-compressed size for a handful of representative import
+                patterns.
+              </p>
+
+              <div className="mb-6 overflow-x-auto rounded-lg border border-border">
+                <table className="w-full text-left">
+                  <caption className="sr-only">
+                    Bundle size comparison for react-web3-icons
+                  </caption>
+                  <thead>
+                    <tr className="border-b border-border bg-surface">
+                      <th className="py-2 pr-4 pl-3 text-xs font-semibold uppercase tracking-wide text-white/50">
+                        Import
+                      </th>
+                      <th className="py-2 pr-4 text-right text-xs font-semibold uppercase tracking-wide text-white/50">
+                        Raw
+                      </th>
+                      <th className="py-2 pr-4 text-right text-xs font-semibold uppercase tracking-wide text-white/50">
+                        Gzip
+                      </th>
+                    </tr>
+                  </thead>
+                  <tbody className="divide-y divide-border">
+                    {[
+                      {
+                        label: 'Single icon (Ethereum)',
+                        raw: '~1.2 KB',
+                        gzip: '~0.6 KB',
+                      },
+                      {
+                        label: 'Full coin category (/coin)',
+                        raw: '~57 KB',
+                        gzip: '~21 KB',
+                      },
+                      {
+                        label: 'Full chain category (/chain)',
+                        raw: '~29 KB',
+                        gzip: '~12 KB',
+                      },
+                      {
+                        label: 'Dynamic loader (/dynamic)',
+                        raw: '~106 KB',
+                        gzip: '~33 KB',
+                      },
+                      {
+                        label: 'Entire library',
+                        raw: '~142 KB',
+                        gzip: '~46 KB',
+                      },
+                    ].map(row => (
+                      <tr key={row.label}>
+                        <td className="py-2 pr-4 pl-3 font-mono text-sm text-white/70">
+                          {row.label}
+                        </td>
+                        <td className="py-2 pr-4 text-right font-mono text-sm text-white/50">
+                          {row.raw}
+                        </td>
+                        <td className="py-2 pr-4 text-right font-mono text-sm text-white/50">
+                          {row.gzip}
+                        </td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+
+              <p className="text-sm text-white/40">
+                Measured with{' '}
+                <code className="rounded bg-surface px-1 font-mono text-xs">
+                  size-limit
+                </code>{' '}
+                on the published ESM build. Single-icon size varies by path
+                complexity.
+              </p>
+            </Section>
+
+            {/* API Comparison */}
+            <Section id="api" title="API Comparison">
+              <p className="mb-4 text-sm text-white/60">
+                Both libraries expose named React components with a{' '}
+                <code className="rounded bg-surface px-1 font-mono text-sm">
+                  size
+                </code>{' '}
+                prop and standard SVG passthrough. The main differences appear
+                when you need dynamic loading or metadata.
+              </p>
+
+              <h3 className="mb-2 mt-6 text-sm font-semibold text-white/80">
+                react-web3-icons
+              </h3>
+              <CodeBlock>{`// Named import — fully tree-shakeable
+import { Ethereum, BitcoinCircle } from 'react-web3-icons';
+// or from a category subpath (smaller bundle entry):
+import { Ethereum } from 'react-web3-icons/chain';
+
+<Ethereum size={32} />
+<BitcoinCircle className="text-orange-500" size={48} />
+
+// Dynamic loading by slug — no static import needed
+import { ChainIcon } from 'react-web3-icons/dynamic';
+<ChainIcon name="ethereum" size={32} />
+
+// Chain ID → component name
+import { CHAIN_ID_TO_NAME } from 'react-web3-icons/meta';
+const name = CHAIN_ID_TO_NAME[1]; // "Ethereum"`}</CodeBlock>
+
+              <h3 className="mb-2 mt-6 text-sm font-semibold text-white/80">
+                @web3icons/react
+              </h3>
+              <CodeBlock>{`// Named import
+import { IconEthereum } from '@web3icons/react';
+
+<IconEthereum size={32} variant="branded" />
+<IconEthereum size={32} variant="mono" />
+<IconEthereum size={32} variant="background" />`}</CodeBlock>
+
+              <p className="mt-4 text-sm text-white/60">
+                Key differences:{' '}
+                <code className="rounded bg-surface px-1 font-mono text-sm">
+                  react-web3-icons
+                </code>{' '}
+                uses separate exported names for each variant (
+                <code className="rounded bg-surface px-1 font-mono text-sm">
+                  Ethereum
+                </code>{' '}
+                vs{' '}
+                <code className="rounded bg-surface px-1 font-mono text-sm">
+                  EthereumMono
+                </code>
+                ), enabling per-variant tree-shaking.{' '}
+                <code className="rounded bg-surface px-1 font-mono text-sm">
+                  @web3icons/react
+                </code>{' '}
+                uses a single component with a{' '}
+                <code className="rounded bg-surface px-1 font-mono text-sm">
+                  variant
+                </code>{' '}
+                prop.
+              </p>
+            </Section>
+
+            {/* Feature Matrix */}
+            <Section id="features" title="Feature Matrix">
+              <div className="overflow-x-auto rounded-lg border border-border">
+                <table className="w-full text-left">
+                  <caption className="sr-only">
+                    Feature comparison between react-web3-icons and
+                    @web3icons/react
+                  </caption>
+                  <thead>
+                    <tr className="border-b border-border bg-surface">
+                      <th className="py-2 pr-4 pl-3 text-xs font-semibold uppercase tracking-wide text-white/50">
+                        Feature
+                      </th>
+                      <th className="py-2 pr-4 text-center text-xs font-semibold uppercase tracking-wide text-white/50">
+                        react-web3-icons
+                      </th>
+                      <th className="py-2 pr-4 text-center text-xs font-semibold uppercase tracking-wide text-white/50">
+                        @web3icons/react
+                      </th>
+                      <th className="hidden py-2 pr-4 text-xs font-semibold uppercase tracking-wide text-white/50 sm:table-cell">
+                        Note
+                      </th>
+                    </tr>
+                  </thead>
+                  <tbody className="divide-y divide-border">
+                    {COMPARISON_ROWS.map(row => (
+                      <tr key={row.feature}>
+                        <td className="py-2.5 pr-4 pl-3 text-sm text-white/70">
+                          {row.feature}
+                        </td>
+                        <td className="py-2.5 pr-4 text-center">{row.ours}</td>
+                        <td className="py-2.5 pr-4 text-center">
+                          {row.theirs}
+                        </td>
+                        <td className="hidden py-2.5 pr-4 text-sm text-white/40 sm:table-cell">
+                          {row.note ?? ''}
+                        </td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+
+              <p className="mt-4 text-sm text-white/40">
+                Data current as of March 2026.{' '}
+                <a
+                  href="https://github.com/0xa3k5/web3icons"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="underline hover:text-white/60"
+                >
+                  @web3icons/react source
+                </a>
+                .
+              </p>
+            </Section>
+          </div>
+        </div>
+
+        {/* Sticky sidebar TOC (desktop only) */}
+        <aside className="hidden lg:block">
+          <nav aria-label="Table of contents" className="sticky top-8">
+            <p className="mb-3 text-xs font-medium uppercase tracking-wide text-white/50">
+              On this page
+            </p>
+            <ul className="flex flex-col gap-1.5 border-l border-border pl-3">
+              {TOC_ITEMS.map(item => (
+                <li key={item.id}>
+                  <a
+                    href={`#${item.id}`}
+                    className="text-sm text-white/50 transition-colors hover:text-white/80"
+                  >
+                    {item.label}
+                  </a>
+                </li>
+              ))}
+            </ul>
+          </nav>
+        </aside>
+      </div>
+    </div>
+  );
+}

--- a/example/src/app/compare/page.tsx
+++ b/example/src/app/compare/page.tsx
@@ -122,9 +122,9 @@ const COMPARISON_ROWS: {
   },
   {
     feature: 'Raw SVG files',
-    ours: <CrossIcon />,
+    ours: <CheckIcon />,
     theirs: <CheckIcon />,
-    note: '@web3icons/core package',
+    note: 'dist/svg/<category>/<Name>.svg',
   },
   {
     feature: 'Figma plugin',

--- a/example/src/components/sections/Header.tsx
+++ b/example/src/components/sections/Header.tsx
@@ -22,6 +22,12 @@ export default function Header() {
         >
           Docs
         </Link>
+        <Link
+          href="/compare"
+          className="rounded text-sm font-medium text-white/60 transition-colors hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent"
+        >
+          Compare
+        </Link>
         <GitHubButton className="cursor-pointer text-2xl text-white/60 transition-colors hover:text-white focus-visible:rounded focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent" />
       </nav>
     </header>


### PR DESCRIPTION
## Summary

- Add library comparison page to the example app
- Compare react-web3-icons against three competitors:
  - **@web3icons/react** — largest catalogue (2,500+ icons), Figma plugin
  - **cryptocurrency-icons** (spothq) — framework-agnostic asset pack (~500 coins), dormant since 2022
  - **@ledgerhq/crypto-icons** — Ledger-ecosystem CDN-based React component
- Sections: Overview, Bundle Size, API Comparison, Feature Matrix
- Add compare-page update reminder to PR template checklist

## Related issue

Closes #571

## Checklist

- [x] Lint passes (`pnpm run check`)
- [x] Tests pass (`pnpm test`)
- [x] Build succeeds (`pnpm run build`)
- [x] Changeset included (if `src/` changed): N/A (example only)
- [x] Official icon source and usage context documented above: N/A
- [x] Default icon geometry/colors match official asset: N/A
- [x] Compare page updated if library features changed: this is the compare page itself

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * 新しい比較ページを追加。複数ライブラリの機能、バンドルサイズ、API を詳細に比較できるようになりました。
  * ヘッダーに比較ページへのナビゲーションリンクを追加し、ユーザーが簡単にアクセスできるようにしました。

* **Chores**
  * プルリクエストテンプレートを更新しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->