### PR TITLE
feat: add static SVG file exports

### DIFF
--- a/.changeset/add-svg-file-exports.md
+++ b/.changeset/add-svg-file-exports.md
@@ -1,0 +1,9 @@
+---
+"react-web3-icons": minor
+---
+
+Add static SVG file exports to the npm package.
+
+Running `pnpm run build` now also executes `scripts/generate-svgs.mjs`, which renders every icon component to a static `.svg` file and writes them to `dist/svg/<category>/<Name>.svg`. These files are included in the published package (already covered by the `"files": ["dist"]` field).
+
+This enables use in non-React environments — Vue, Svelte, Angular, static HTML, CDN delivery, Figma plugins, and any toolchain that can import or reference plain SVG files.

--- a/package.json
+++ b/package.json
@@ -123,7 +123,8 @@
   ],
   "scripts": {
     "analyze": "size-limit --why",
-    "build": "tsdown",
+    "build": "tsdown && node scripts/generate-svgs.mjs",
+    "generate-svgs": "node scripts/generate-svgs.mjs",
     "check": "biome ci",
     "format": "biome format --write",
     "lint": "biome check",

--- a/scripts/generate-svgs.mjs
+++ b/scripts/generate-svgs.mjs
@@ -8,8 +8,9 @@
  * Output: dist/svg/<category>/<Name>.svg
  */
 
-import { existsSync, mkdirSync, writeFileSync } from 'node:fs';
+import { existsSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
 import { join, resolve } from 'node:path';
+import { pathToFileURL } from 'node:url';
 import { createElement } from 'react';
 import { renderToStaticMarkup } from 'react-dom/server';
 
@@ -52,6 +53,9 @@ function cleanSvg(html) {
   );
 }
 
+// Clear stale SVGs from previous runs before writing fresh output
+rmSync(SVG_OUT, { recursive: true, force: true });
+
 let total = 0;
 let skipped = 0;
 
@@ -66,7 +70,7 @@ for (const category of CATEGORIES) {
   mkdirSync(outDir, { recursive: true });
 
   /** @type {Record<string, unknown>} */
-  const mod = await import(indexPath);
+  const mod = await import(pathToFileURL(indexPath).href);
 
   for (const [name, Component] of Object.entries(mod)) {
     if (SKIP_NAMES.has(name)) continue;

--- a/scripts/generate-svgs.mjs
+++ b/scripts/generate-svgs.mjs
@@ -49,9 +49,6 @@ function cleanSvg(html) {
       .replace(/\s+aria-hidden="true"/g, '')
       // Remove role="img" (add back if needed per use case)
       .replace(/\s+role="img"/g, '')
-      // Remove inline width/height="1em" — let viewBox control sizing
-      .replace(/\s+width="1em"/g, '')
-      .replace(/\s+height="1em"/g, '')
   );
 }
 

--- a/scripts/generate-svgs.mjs
+++ b/scripts/generate-svgs.mjs
@@ -1,0 +1,99 @@
+#!/usr/bin/env node
+/**
+ * Generates static SVG files from all built icon components.
+ *
+ * Run after `pnpm run build`:
+ *   node scripts/generate-svgs.mjs
+ *
+ * Output: dist/svg/<category>/<Name>.svg
+ */
+
+import { existsSync, mkdirSync, writeFileSync } from 'node:fs';
+import { join, resolve } from 'node:path';
+import { createElement } from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+
+const ROOT = resolve(import.meta.dirname, '..');
+const DIST = resolve(ROOT, 'dist');
+const SVG_OUT = resolve(DIST, 'svg');
+
+const CATEGORIES = [
+  'bridge',
+  'chain',
+  'coin',
+  'defi',
+  'devtool',
+  'dex',
+  'domain',
+  'exchange',
+  'explorer',
+  'marketplace',
+  'node',
+  'portfolio',
+  'storage',
+  'tracker',
+  'wallet',
+];
+
+// Non-icon exports to skip
+const SKIP_NAMES = new Set([
+  'IconContext',
+  'DEPRECATED_ICON_NAMES',
+]);
+
+/** Strip render-context attributes not meaningful in standalone SVG files */
+function cleanSvg(html) {
+  return (
+    html
+      // Remove aria-hidden (standalone SVGs don't need it)
+      .replace(/\s+aria-hidden="true"/g, '')
+      // Remove role="img" (add back if needed per use case)
+      .replace(/\s+role="img"/g, '')
+      // Remove inline width/height="1em" — let viewBox control sizing
+      .replace(/\s+width="1em"/g, '')
+      .replace(/\s+height="1em"/g, '')
+  );
+}
+
+let total = 0;
+let skipped = 0;
+
+for (const category of CATEGORIES) {
+  const indexPath = join(DIST, category, 'index.mjs');
+  if (!existsSync(indexPath)) {
+    console.warn(`  skip ${category}: no dist/${category}/index.mjs`);
+    continue;
+  }
+
+  const outDir = join(SVG_OUT, category);
+  mkdirSync(outDir, { recursive: true });
+
+  /** @type {Record<string, unknown>} */
+  const mod = await import(indexPath);
+
+  for (const [name, Component] of Object.entries(mod)) {
+    if (SKIP_NAMES.has(name)) continue;
+
+    // Only render function components / forwardRef components
+    if (typeof Component !== 'function' && !(typeof Component === 'object' && Component !== null && '$$typeof' in Component)) {
+      skipped++;
+      continue;
+    }
+
+    try {
+      const html = renderToStaticMarkup(
+        createElement(Component, { size: '24' }),
+      );
+      const svg = cleanSvg(html);
+      writeFileSync(join(outDir, `${name}.svg`), svg, 'utf8');
+      total++;
+    } catch (err) {
+      console.warn(`  warn: failed to render ${category}/${name}: ${err.message}`);
+      skipped++;
+    }
+  }
+
+  console.log(`✓ ${category}: generated SVGs in dist/svg/${category}/`);
+}
+
+console.log(`\nDone: ${total} SVGs written, ${skipped} skipped.`);


### PR DESCRIPTION
## Summary

- Adds `scripts/generate-svgs.mjs` that renders every icon component with `renderToStaticMarkup` and writes the output to `dist/svg/<category>/<Name>.svg`
- Integrates as a post-build step (`tsdown && node scripts/generate-svgs.mjs`)
- Also available as `pnpm run generate-svgs` standalone
- 629 SVG files generated from 15 categories
- No new npm dependencies needed (`react-dom` is already a peer dep; `react-dom` devDep covers the build)
- SVGs are included in the published package via the existing `"files": ["dist"]` field

## Usage

```bash
# After npm install, SVGs are available at:
node_modules/react-web3-icons/dist/svg/chain/Ethereum.svg
node_modules/react-web3-icons/dist/svg/coin/Btc.svg
node_modules/react-web3-icons/dist/svg/wallet/MetaMask.svg
# ...
```

For build tools that support SVG imports:
```js
import ethereumSvg from 'react-web3-icons/dist/svg/chain/Ethereum.svg';
```

## Related issue

Closes #562

## Checklist

- [x] Builds successfully — `pnpm run build` generates 629 SVGs
- [x] Biome lint passes
- [x] Tests pass
- [x] Changeset added (minor)
- [x] No breaking changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **新機能**
  * アイコンの静的SVGファイル出力に対応しました。npmパッケージにSVGファイルが含まれ、React以外の環境でもSVGを直接利用できます。
* **改善**
  * ビルド処理にSVG生成ステップを追加し、すべてのアイコンから個別のSVGファイルを自動生成するようになりました。生成状況はログ出力で確認できます。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->