### PR TITLE
fix(example): remove time-sensitive static data from compare page

### DIFF
--- a/example/src/app/compare/page.tsx
+++ b/example/src/app/compare/page.tsx
@@ -227,17 +227,6 @@ const COMPARISON_ROWS: {
       ledger: <span className="text-sm text-white/70">CDN-based</span>,
     },
   },
-  {
-    feature: 'npm weekly downloads',
-    ours: <span className="text-sm text-white/70">~100</span>,
-    competitors: {
-      web3icons: <span className="text-sm text-white/70">~24k</span>,
-      'cryptocurrency-icons': (
-        <span className="text-sm text-white/70">~14k</span>
-      ),
-      ledger: <span className="text-sm text-white/70">~13k</span>,
-    },
-  },
 ];
 
 export default function ComparePage() {
@@ -292,8 +281,8 @@ export default function ComparePage() {
                       cryptocurrency-icons
                     </strong>{' '}
                     (spothq) is a framework-agnostic SVG/PNG asset pack with
-                    ~500 coins and 2,700+ GitHub stars, but has been dormant
-                    since 2022 and provides no React components.
+                    ~500 coins, but has been dormant since 2022 and provides no
+                    React components.
                   </span>
                 </li>
                 <li className="flex gap-2">
@@ -527,7 +516,7 @@ import { CryptoIcon } from '@ledgerhq/crypto-icons';
               </div>
 
               <p className="mt-4 text-sm text-white/40">
-                Data current as of March 2026. Sources:{' '}
+                Sources:{' '}
                 <a
                   href="https://github.com/0xa3k5/web3icons"
                   target="_blank"
@@ -554,7 +543,16 @@ import { CryptoIcon } from '@ledgerhq/crypto-icons';
                 >
                   @ledgerhq/crypto-icons
                 </a>
-                .
+                . See{' '}
+                <a
+                  href="https://npmtrends.com/react-web3-icons-vs-@web3icons/react-vs-cryptocurrency-icons-vs-@ledgerhq/crypto-icons"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="underline hover:text-white/60"
+                >
+                  npm trends
+                </a>{' '}
+                for live download stats.
               </p>
             </Section>
           </div>

--- a/example/src/app/compare/page.tsx
+++ b/example/src/app/compare/page.tsx
@@ -204,7 +204,7 @@ const COMPARISON_ROWS: {
       'cryptocurrency-icons': <CrossIcon />,
       ledger: <CheckIcon />,
     },
-    note: 'cryptocurrency-icons last updated 2022',
+    note: 'cryptocurrency-icons is no longer maintained',
   },
   {
     feature: 'React Native support',
@@ -281,8 +281,8 @@ export default function ComparePage() {
                       cryptocurrency-icons
                     </strong>{' '}
                     (spothq) is a framework-agnostic SVG/PNG asset pack with
-                    ~500 coins, but has been dormant since 2022 and provides no
-                    React components.
+                    ~500 coins, but is no longer actively maintained and
+                    provides no React components.
                   </span>
                 </li>
                 <li className="flex gap-2">


### PR DESCRIPTION
## Summary

- Remove npm weekly downloads row from feature matrix (static numbers go stale immediately)
- Remove "Data current as of March 2026" date stamp
- Remove specific GitHub star count (2,700+) from overview text
- Add [npmtrends](https://npmtrends.com/react-web3-icons-vs-@web3icons/react-vs-cryptocurrency-icons-vs-@ledgerhq/crypto-icons) link for live download comparison

## Related issue

Closes #656

## Checklist

- [x] Lint passes (`pnpm run check`)
- [x] Tests pass (`pnpm test`)
- [x] Build succeeds (`pnpm run build`)
- [x] Changeset included (if `src/` changed): N/A (example only)
- [x] Official icon source and usage context documented above: N/A
- [x] Default icon geometry/colors match official asset: N/A
- [x] Compare page updated if library features changed: N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **ドキュメント**
  * 機能比較マトリックスを更新し、不要な行を削除しました。
  * 仮想通貨アイコンの説明文を簡潔に整理しました。
  * npm trendsへの直接リンクを追加し、最新のダウンロード統計情報にアクセス可能にしました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->