### PR TITLE
feat(example): add background toggle to icon grid

### DIFF
--- a/example/src/components/elements/IconCard.tsx
+++ b/example/src/components/elements/IconCard.tsx
@@ -1,14 +1,16 @@
 'use client';
 
+import type { CSSProperties } from 'react';
+
 import type { IconComponent } from '../../types/icons';
-import { bgStyle, type PreviewBg } from '../../utils/bgStyle';
 
 interface Props {
   base: string;
   activeVariant: string;
   components: Record<string, IconComponent>;
   highlighted?: boolean;
-  previewBg?: PreviewBg;
+  lightMode?: boolean;
+  cardStyle?: CSSProperties;
   onClick: () => void;
 }
 
@@ -17,30 +19,36 @@ export default function IconCard({
   activeVariant,
   components,
   highlighted = false,
-  previewBg = 'dark',
+  lightMode = false,
+  cardStyle,
   onClick,
 }: Props) {
   const Icon = components[activeVariant] as IconComponent | undefined;
-  const showBg = previewBg !== 'dark';
+
+  const borderClass = highlighted
+    ? 'border-accent bg-accent/10'
+    : lightMode
+      ? 'border-black/10 bg-white'
+      : 'border-border bg-surface';
+
+  const hoverClass = lightMode
+    ? 'hover:border-black/20 hover:bg-gray-50'
+    : 'hover:border-white/15 hover:bg-surface-hover';
+
+  const labelClass = lightMode ? 'text-black/50' : 'text-white/50';
 
   return (
     <button
       type="button"
       aria-label={`View ${base} icon details`}
       onClick={onClick}
-      className={`flex w-full cursor-pointer flex-col items-center gap-2 rounded-lg border p-4 transition-all duration-200 hover:border-white/15 hover:bg-surface-hover focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-inset ${
-        highlighted ? 'border-accent bg-accent/10' : 'border-border bg-surface'
-      }`}
+      style={cardStyle}
+      className={`flex w-full cursor-pointer flex-col items-center gap-2 rounded-lg border p-4 transition-all duration-200 ${hoverClass} focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-inset ${borderClass}`}
     >
-      {Icon && (
-        <div
-          className={`flex items-center justify-center ${showBg ? 'rounded p-1' : ''}`}
-          style={showBg ? bgStyle(previewBg) : undefined}
-        >
-          <Icon className="text-4xl" />
-        </div>
-      )}
-      <p className="w-full truncate text-center font-mono text-[11px] text-white/50">
+      {Icon && <Icon className="text-4xl" />}
+      <p
+        className={`w-full truncate text-center font-mono text-[11px] ${labelClass}`}
+      >
         {base}
       </p>
     </button>

--- a/example/src/components/elements/IconCard.tsx
+++ b/example/src/components/elements/IconCard.tsx
@@ -1,12 +1,14 @@
 'use client';
 
 import type { IconComponent } from '../../types/icons';
+import { bgStyle, type PreviewBg } from '../../utils/bgStyle';
 
 interface Props {
   base: string;
   activeVariant: string;
   components: Record<string, IconComponent>;
   highlighted?: boolean;
+  previewBg?: PreviewBg;
   onClick: () => void;
 }
 
@@ -15,9 +17,11 @@ export default function IconCard({
   activeVariant,
   components,
   highlighted = false,
+  previewBg = 'dark',
   onClick,
 }: Props) {
   const Icon = components[activeVariant] as IconComponent | undefined;
+  const showBg = previewBg !== 'dark';
 
   return (
     <button
@@ -28,7 +32,14 @@ export default function IconCard({
         highlighted ? 'border-accent bg-accent/10' : 'border-border bg-surface'
       }`}
     >
-      {Icon && <Icon className="text-4xl" />}
+      {Icon && (
+        <div
+          className={`flex items-center justify-center ${showBg ? 'rounded p-1' : ''}`}
+          style={showBg ? bgStyle(previewBg) : undefined}
+        >
+          <Icon className="text-4xl" />
+        </div>
+      )}
       <p className="w-full truncate text-center font-mono text-[11px] text-white/50">
         {base}
       </p>

--- a/example/src/components/elements/IconDrawer.tsx
+++ b/example/src/components/elements/IconDrawer.tsx
@@ -1,10 +1,10 @@
 'use client';
 
-import type { CSSProperties } from 'react';
 import { useCallback, useEffect, useRef, useState } from 'react';
 
 import { useCopyAction } from '../../hooks/useCopyAction';
 import type { IconComponent } from '../../types/icons';
+import { bgStyle, type PreviewBg } from '../../utils/bgStyle';
 import CopyToggleIcon from './CopyToggleIcon';
 
 interface Props {
@@ -102,18 +102,6 @@ function downloadSvg(name: string, container: HTMLElement | null) {
   URL.revokeObjectURL(url);
 }
 
-/** Background style helper used in both normal and compare previews */
-function bgStyle(bg: 'dark' | 'light' | 'checker'): CSSProperties {
-  if (bg === 'light') return { backgroundColor: '#fff' };
-  if (bg === 'checker')
-    return {
-      backgroundImage:
-        'repeating-conic-gradient(#808080 0% 25%, transparent 0% 50%)',
-      backgroundSize: '8px 8px',
-    };
-  return { backgroundColor: '#111' };
-}
-
 export default function IconDrawer({
   base,
   variants,
@@ -128,9 +116,7 @@ export default function IconDrawer({
   const [previewSize, setPreviewSize] = useState(64);
   const [previewColor, setPreviewColor] = useState('');
   const [compareMode, setCompareMode] = useState(false);
-  const [previewBg, setPreviewBg] = useState<'dark' | 'light' | 'checker'>(
-    'dark',
-  );
+  const [previewBg, setPreviewBg] = useState<PreviewBg>('dark');
   const [svgMarkup, setSvgMarkup] = useState('');
   const [open, setOpen] = useState(false);
   const iconRef = useRef<HTMLDivElement>(null);

--- a/example/src/components/sections/IconTable.tsx
+++ b/example/src/components/sections/IconTable.tsx
@@ -1,19 +1,17 @@
 'use client';
 
 import { parseAsString, useQueryState } from 'nuqs';
+import type { CSSProperties } from 'react';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
 import * as iconModules from 'react-web3-icons';
 import { useIconFilter } from '../../hooks/useIconFilter';
 import type { IconComponent, Variant } from '../../types/icons';
-import { bgStyle, type PreviewBg } from '../../utils/bgStyle';
 import { groupIcons } from '../../utils/groupIcons';
 import { REACT_WEB3_ICONS } from '../../utils/icons';
 import IconCard from '../elements/IconCard';
 import IconDrawer from '../elements/IconDrawer';
 import SearchForm from '../elements/SearchForm';
-
-const BG_OPTIONS: PreviewBg[] = ['dark', 'light', 'checker'];
 
 const VARIANT_LABELS: Record<Variant, string> = {
   all: 'All',
@@ -24,6 +22,8 @@ const VARIANT_LABELS: Record<Variant, string> = {
 const VARIANTS: Variant[] = ['all', 'colored', 'mono'];
 
 const PAGE_SIZE = 120;
+
+type GridBg = 'dark' | 'light' | 'custom';
 
 export default function IconTable() {
   const [rawCategory] = useQueryState(
@@ -39,7 +39,8 @@ export default function IconTable() {
     parseAsString.withDefault('').withOptions({ history: 'push' }),
   );
   const [variant, setVariant] = useState<Variant>('all');
-  const [previewBg, setPreviewBg] = useState<PreviewBg>('dark');
+  const [gridBg, setGridBg] = useState<GridBg>('dark');
+  const [customColor, setCustomColor] = useState('#ffffff');
   const [visibleCount, setVisibleCount] = useState(PAGE_SIZE);
 
   const validCategory = Object.hasOwn(REACT_WEB3_ICONS, rawCategory)
@@ -150,6 +151,15 @@ export default function IconTable() {
     }
   }, [linkedIcon, setLinkedIcon]);
 
+  // Grid background styling
+  const isLightMode = gridBg !== 'dark';
+  const gridPanelStyle: CSSProperties | undefined =
+    gridBg === 'light'
+      ? { backgroundColor: '#ffffff' }
+      : gridBg === 'custom'
+        ? { backgroundColor: customColor }
+        : undefined;
+
   return (
     <section
       id="icon-grid"
@@ -187,22 +197,75 @@ export default function IconTable() {
             ))}
           </fieldset>
 
-          <fieldset className="flex items-center gap-1.5 rounded-lg border border-border bg-surface px-2.5 py-2">
-            <legend className="sr-only">Preview background</legend>
-            <span className="text-xs text-white/50">BG</span>
-            {BG_OPTIONS.map(bg => (
-              <button
-                key={bg}
-                type="button"
-                onClick={() => setPreviewBg(bg)}
-                className={`h-5 w-5 rounded border transition-colors ${
-                  previewBg === bg ? 'border-accent' : 'border-border'
-                }`}
-                style={bgStyle(bg)}
-                aria-label={`${bg} background`}
-                aria-pressed={previewBg === bg}
+          <fieldset className="flex items-center gap-1 rounded-lg border border-border bg-surface px-1.5 py-1">
+            <legend className="sr-only">Grid background</legend>
+            {/* Dark button */}
+            <button
+              type="button"
+              onClick={() => setGridBg('dark')}
+              aria-label="Dark background"
+              aria-pressed={gridBg === 'dark'}
+              className={`flex h-8 w-8 items-center justify-center rounded transition-colors ${
+                gridBg === 'dark'
+                  ? 'bg-white/10 text-white'
+                  : 'text-white/40 hover:text-white/60'
+              }`}
+            >
+              <svg
+                viewBox="0 0 16 16"
+                className="h-4 w-4"
+                fill="currentColor"
+                aria-hidden="true"
+              >
+                <path d="M8 1a7 7 0 1 0 0 14A7 7 0 0 0 8 1Zm0 12.5a5.5 5.5 0 0 1 0-11v11Z" />
+              </svg>
+            </button>
+            {/* Light button */}
+            <button
+              type="button"
+              onClick={() => setGridBg('light')}
+              aria-label="Light background"
+              aria-pressed={gridBg === 'light'}
+              className={`flex h-8 w-8 items-center justify-center rounded transition-colors ${
+                gridBg === 'light'
+                  ? 'bg-white/10 text-white'
+                  : 'text-white/40 hover:text-white/60'
+              }`}
+            >
+              <svg
+                viewBox="0 0 16 16"
+                className="h-4 w-4"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth={1.5}
+                strokeLinecap="round"
+                aria-hidden="true"
+              >
+                <circle cx={8} cy={8} r={3.5} />
+                <path d="M8 1.5v1M8 13.5v1M1.5 8h1M13.5 8h1M3.4 3.4l.7.7M11.9 11.9l.7.7M3.4 12.6l.7-.7M11.9 4.1l.7-.7" />
+              </svg>
+            </button>
+            {/* Custom color picker */}
+            <label
+              className={`relative flex h-8 w-8 cursor-pointer items-center justify-center rounded transition-colors ${
+                gridBg === 'custom' ? 'ring-2 ring-accent ring-inset' : ''
+              }`}
+            >
+              <input
+                type="color"
+                value={customColor}
+                onChange={e => {
+                  setCustomColor(e.target.value);
+                  setGridBg('custom');
+                }}
+                className="absolute inset-0 cursor-pointer opacity-0"
+                aria-label="Custom background color"
               />
-            ))}
+              <span
+                className="h-5 w-5 rounded-full border border-white/20"
+                style={{ backgroundColor: customColor }}
+              />
+            </label>
           </fieldset>
         </div>
       </div>
@@ -252,10 +315,13 @@ export default function IconTable() {
           <p className="text-sm">Try a different search term</p>
         </div>
       ) : (
-        <>
+        <div
+          className={`mt-6 rounded-xl transition-colors duration-200 ${isLightMode ? 'p-2' : ''}`}
+          style={gridPanelStyle}
+        >
           <ul
             key={`${validCategory}-${variant}`}
-            className="mt-6 grid list-none grid-cols-[repeat(auto-fill,minmax(88px,1fr))] gap-0 sm:grid-cols-[repeat(auto-fill,minmax(112px,1fr))]"
+            className="grid list-none grid-cols-[repeat(auto-fill,minmax(88px,1fr))] gap-0 sm:grid-cols-[repeat(auto-fill,minmax(112px,1fr))]"
           >
             {visibleGroups.map(group => (
               <li key={group.base} data-icon-name={group.base} className="p-2">
@@ -264,7 +330,7 @@ export default function IconTable() {
                   activeVariant={group.activeVariant}
                   components={group.components}
                   highlighted={linkedIcon === group.base}
-                  previewBg={previewBg}
+                  lightMode={isLightMode}
                   onClick={() => handleOpenDrawer(group.base)}
                 />
               </li>
@@ -279,7 +345,7 @@ export default function IconTable() {
               <div className="h-6 w-6 animate-spin rounded-full border-2 border-white/10 border-t-accent" />
             </div>
           )}
-        </>
+        </div>
       )}
 
       {/* Detail drawer */}

--- a/example/src/components/sections/IconTable.tsx
+++ b/example/src/components/sections/IconTable.tsx
@@ -6,11 +6,14 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import * as iconModules from 'react-web3-icons';
 import { useIconFilter } from '../../hooks/useIconFilter';
 import type { IconComponent, Variant } from '../../types/icons';
+import { bgStyle, type PreviewBg } from '../../utils/bgStyle';
 import { groupIcons } from '../../utils/groupIcons';
 import { REACT_WEB3_ICONS } from '../../utils/icons';
 import IconCard from '../elements/IconCard';
 import IconDrawer from '../elements/IconDrawer';
 import SearchForm from '../elements/SearchForm';
+
+const BG_OPTIONS: PreviewBg[] = ['dark', 'light', 'checker'];
 
 const VARIANT_LABELS: Record<Variant, string> = {
   all: 'All',
@@ -36,6 +39,7 @@ export default function IconTable() {
     parseAsString.withDefault('').withOptions({ history: 'push' }),
   );
   const [variant, setVariant] = useState<Variant>('all');
+  const [previewBg, setPreviewBg] = useState<PreviewBg>('dark');
   const [visibleCount, setVisibleCount] = useState(PAGE_SIZE);
 
   const validCategory = Object.hasOwn(REACT_WEB3_ICONS, rawCategory)
@@ -163,24 +167,44 @@ export default function IconTable() {
           />
         </div>
 
-        <fieldset className="flex shrink-0 overflow-hidden rounded-lg border border-border bg-surface">
-          <legend className="sr-only">Icon variant filter</legend>
-          {VARIANTS.map(v => (
-            <button
-              key={v}
-              type="button"
-              onClick={() => setVariant(v)}
-              aria-pressed={variant === v}
-              className={`h-11 px-4 text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-accent ${
-                variant === v
-                  ? 'bg-white/10 text-white'
-                  : 'text-white/50 hover:bg-white/5 hover:text-white/60'
-              }`}
-            >
-              {VARIANT_LABELS[v]}
-            </button>
-          ))}
-        </fieldset>
+        <div className="flex shrink-0 items-center gap-2">
+          <fieldset className="flex overflow-hidden rounded-lg border border-border bg-surface">
+            <legend className="sr-only">Icon variant filter</legend>
+            {VARIANTS.map(v => (
+              <button
+                key={v}
+                type="button"
+                onClick={() => setVariant(v)}
+                aria-pressed={variant === v}
+                className={`h-11 px-4 text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-accent ${
+                  variant === v
+                    ? 'bg-white/10 text-white'
+                    : 'text-white/50 hover:bg-white/5 hover:text-white/60'
+                }`}
+              >
+                {VARIANT_LABELS[v]}
+              </button>
+            ))}
+          </fieldset>
+
+          <fieldset className="flex items-center gap-1.5 rounded-lg border border-border bg-surface px-2.5 py-2">
+            <legend className="sr-only">Preview background</legend>
+            <span className="text-xs text-white/50">BG</span>
+            {BG_OPTIONS.map(bg => (
+              <button
+                key={bg}
+                type="button"
+                onClick={() => setPreviewBg(bg)}
+                className={`h-5 w-5 rounded border transition-colors ${
+                  previewBg === bg ? 'border-accent' : 'border-border'
+                }`}
+                style={bgStyle(bg)}
+                aria-label={`${bg} background`}
+                aria-pressed={previewBg === bg}
+              />
+            ))}
+          </fieldset>
+        </div>
       </div>
 
       <p id="icon-count" className="sr-only" aria-live="polite">
@@ -240,6 +264,7 @@ export default function IconTable() {
                   activeVariant={group.activeVariant}
                   components={group.components}
                   highlighted={linkedIcon === group.base}
+                  previewBg={previewBg}
                   onClick={() => handleOpenDrawer(group.base)}
                 />
               </li>

--- a/example/src/utils/bgStyle.ts
+++ b/example/src/utils/bgStyle.ts
@@ -1,0 +1,15 @@
+import type { CSSProperties } from 'react';
+
+export type PreviewBg = 'dark' | 'light' | 'checker';
+
+/** Background style helper for icon preview areas */
+export function bgStyle(bg: PreviewBg): CSSProperties {
+  if (bg === 'light') return { backgroundColor: '#fff' };
+  if (bg === 'checker')
+    return {
+      backgroundImage:
+        'repeating-conic-gradient(#808080 0% 25%, transparent 0% 50%)',
+      backgroundSize: '8px 8px',
+    };
+  return { backgroundColor: '#111' };
+}


### PR DESCRIPTION
## Summary

- Add dark/light/checker background toggle to the icon grid toolbar for better visibility of dark-colored icons
- Extract `bgStyle` helper to shared utility (`example/src/utils/bgStyle.ts`), used by both IconTable and IconDrawer
- Default remains dark to preserve the current look

## Related issue

Closes #658

## Checklist

- [x] `pnpm run check` passes
- [x] `pnpm run typecheck` passes
- [x] `pnpm run build` passes
- [x] Visual verification: all three BG modes (dark/light/checker) confirmed working via Chrome DevTools

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# リリースノート

* **新機能**
  * グリッド背景のカスタマイズ機能を追加しました。ダーク、ライト、カスタムの3つの背景オプションから選択できるようになります。
  * カラーピッカーで背景色をカスタマイズできるようになりました。
  * ライトモードサポートを実装し、異なる背景での視認性が向上しました。

* **リファクタリング**
  * 背景スタイル処理の共通化により、コード管理を改善しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->