### PR TITLE
feat(example): implement full dark/light theme toggle

### DIFF
--- a/example/src/app/layout.tsx
+++ b/example/src/app/layout.tsx
@@ -56,7 +56,7 @@ export default function RootLayout({ children }: { children: ReactNode }) {
   return (
     <html lang="en" className={`${inter.variable} ${jetbrainsMono.variable}`}>
       <head>
-        <meta name="theme-color" content="#080808" />
+        <meta name="theme-color" content="#0f0f0f" />
       </head>
       <body>
         <Providers>
@@ -66,7 +66,7 @@ export default function RootLayout({ children }: { children: ReactNode }) {
           >
             Skip to icons
           </a>
-          <div className="flex min-h-svh flex-col">
+          <div className="flex min-h-svh flex-col theme-transition">
             <Header />
             <main className="flex-1">{children}</main>
             <Footer />

--- a/example/src/app/providers.tsx
+++ b/example/src/app/providers.tsx
@@ -2,7 +2,12 @@
 
 import { NuqsAdapter } from 'nuqs/adapters/next/app';
 import type { ReactNode } from 'react';
+import { ThemeProvider } from '../hooks/useTheme';
 
 export function Providers({ children }: { children: ReactNode }) {
-  return <NuqsAdapter>{children}</NuqsAdapter>;
+  return (
+    <NuqsAdapter>
+      <ThemeProvider>{children}</ThemeProvider>
+    </NuqsAdapter>
+  );
 }

--- a/example/src/components/elements/IconCard.tsx
+++ b/example/src/components/elements/IconCard.tsx
@@ -1,7 +1,5 @@
 'use client';
 
-import type { CSSProperties } from 'react';
-
 import type { IconComponent } from '../../types/icons';
 
 interface Props {
@@ -9,8 +7,6 @@ interface Props {
   activeVariant: string;
   components: Record<string, IconComponent>;
   highlighted?: boolean;
-  lightMode?: boolean;
-  cardStyle?: CSSProperties;
   onClick: () => void;
 }
 
@@ -19,36 +15,23 @@ export default function IconCard({
   activeVariant,
   components,
   highlighted = false,
-  lightMode = false,
-  cardStyle,
   onClick,
 }: Props) {
   const Icon = components[activeVariant] as IconComponent | undefined;
 
   const borderClass = highlighted
     ? 'border-accent bg-accent/10'
-    : lightMode
-      ? 'border-black/10 bg-white'
-      : 'border-border bg-surface';
-
-  const hoverClass = lightMode
-    ? 'hover:border-black/20 hover:bg-gray-50'
-    : 'hover:border-white/15 hover:bg-surface-hover';
-
-  const labelClass = lightMode ? 'text-black/50' : 'text-white/50';
+    : 'border-border bg-surface';
 
   return (
     <button
       type="button"
       aria-label={`View ${base} icon details`}
       onClick={onClick}
-      style={cardStyle}
-      className={`flex w-full cursor-pointer flex-col items-center gap-2 rounded-lg border p-4 transition-all duration-200 ${hoverClass} focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-inset ${borderClass}`}
+      className={`flex w-full cursor-pointer flex-col items-center gap-2 rounded-lg border p-4 transition-all duration-200 hover:border-fg/15 hover:bg-surface-hover focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-inset ${borderClass}`}
     >
       {Icon && <Icon className="text-4xl" />}
-      <p
-        className={`w-full truncate text-center font-mono text-[11px] ${labelClass}`}
-      >
+      <p className="w-full truncate text-center font-mono text-[11px] text-fg/50">
         {base}
       </p>
     </button>

--- a/example/src/components/elements/IconDrawer.tsx
+++ b/example/src/components/elements/IconDrawer.tsx
@@ -37,7 +37,7 @@ function CopyButton({ text }: { text: string }) {
       type="button"
       onClick={() => copy(text)}
       aria-label="Copy to clipboard"
-      className="flex min-h-11 min-w-11 items-center justify-center rounded text-white/50 transition-colors hover:bg-white/10 hover:text-white/60"
+      className="flex min-h-11 min-w-11 items-center justify-center rounded text-fg/50 transition-colors hover:bg-fg/10 hover:text-fg/60"
     >
       <CopyToggleIcon copied={copied} />
     </button>
@@ -53,7 +53,7 @@ function ShareButton() {
       onClick={() => copy(window.location.href)}
       aria-label={copied ? 'Link copied' : 'Copy link to this icon'}
       title={copied ? 'Link copied!' : 'Copy link'}
-      className="flex min-h-11 min-w-11 items-center justify-center rounded text-white/50 transition-colors hover:bg-white/10 hover:text-white/60"
+      className="flex min-h-11 min-w-11 items-center justify-center rounded text-fg/50 transition-colors hover:bg-fg/10 hover:text-fg/60"
     >
       {copied ? (
         <svg
@@ -235,21 +235,21 @@ export default function IconDrawer({
     >
       <div
         ref={drawerRef}
-        className={`flex h-full w-full flex-col overflow-y-auto border-l border-border bg-[#0a0a0a] transition-transform duration-300 ease-out sm:max-w-md ${open ? 'translate-x-0' : 'translate-x-full'}`}
+        className={`flex h-full w-full flex-col overflow-y-auto border-l border-border bg-bg transition-transform duration-300 ease-out sm:max-w-md ${open ? 'translate-x-0' : 'translate-x-full'}`}
         role="dialog"
         aria-label={`${base} icon details`}
         aria-modal="true"
       >
         {/* Header */}
         <div className="flex items-center justify-between border-b border-border px-5 py-4">
-          <h2 className="text-lg font-semibold text-white">{base}</h2>
+          <h2 className="text-lg font-semibold text-fg">{base}</h2>
           <div className="flex items-center gap-0.5">
             <ShareButton />
             <button
               type="button"
               onClick={onClose}
               aria-label="Close drawer"
-              className="rounded p-1 text-white/50 transition-colors hover:bg-white/10 hover:text-white"
+              className="rounded p-1 text-fg/50 transition-colors hover:bg-fg/10 hover:text-fg"
             >
               <svg
                 viewBox="0 0 24 24"
@@ -269,7 +269,7 @@ export default function IconDrawer({
 
         {/* Preview background selector */}
         <div className="flex items-center gap-2 border-b border-border px-5 py-2">
-          <span className="text-xs text-white/50">BG</span>
+          <span className="text-xs text-fg/50">BG</span>
           {(['dark', 'light', 'checker'] as const).map(bg => (
             <button
               key={bg}
@@ -292,7 +292,7 @@ export default function IconDrawer({
               className={`rounded px-2 py-0.5 text-xs font-medium transition-colors ${
                 compareMode
                   ? 'bg-accent/20 text-accent'
-                  : 'bg-white/5 text-white/50 hover:text-white/60'
+                  : 'bg-fg/5 text-fg/50 hover:text-fg/60'
               }`}
             >
               Compare
@@ -319,7 +319,7 @@ export default function IconDrawer({
                       setSelected(v);
                       setCompareMode(false);
                     }}
-                    className="flex flex-col items-center gap-2 rounded-lg p-3 transition-colors hover:bg-white/5"
+                    className="flex flex-col items-center gap-2 rounded-lg p-3 transition-colors hover:bg-fg/5"
                   >
                     <div
                       className="flex items-center justify-center rounded-lg p-3"
@@ -375,7 +375,7 @@ export default function IconDrawer({
 
             {/* Variant selector */}
             <div className="border-b border-border px-5 py-4">
-              <p className="mb-3 text-xs font-medium uppercase tracking-wide text-white/50">
+              <p className="mb-3 text-xs font-medium uppercase tracking-wide text-fg/50">
                 Variants
               </p>
               <div
@@ -400,7 +400,7 @@ export default function IconDrawer({
                       className={`flex h-12 w-12 items-center justify-center rounded-lg border transition-colors ${
                         isSelected
                           ? 'border-accent bg-accent/10'
-                          : 'border-border bg-surface hover:border-white/20'
+                          : 'border-border bg-surface hover:border-fg/20'
                       }`}
                     >
                       {VariantIcon && <VariantIcon className="text-2xl" />}
@@ -415,10 +415,10 @@ export default function IconDrawer({
         {/* Size control */}
         <div className="border-b border-border px-5 py-4">
           <div className="mb-3 flex items-center justify-between">
-            <p className="text-xs font-medium uppercase tracking-wide text-white/50">
+            <p className="text-xs font-medium uppercase tracking-wide text-fg/50">
               Size
             </p>
-            <span className="font-mono text-xs text-white/50">
+            <span className="font-mono text-xs text-fg/50">
               {previewSize}px
             </span>
           </div>
@@ -429,7 +429,7 @@ export default function IconDrawer({
               max={128}
               value={previewSize}
               onChange={e => setPreviewSize(Number(e.target.value))}
-              className="h-1.5 flex-1 cursor-pointer appearance-none rounded-full bg-white/10 accent-accent"
+              className="h-1.5 flex-1 cursor-pointer appearance-none rounded-full bg-fg/10 accent-accent"
               aria-label="Preview size"
             />
           </div>
@@ -442,7 +442,7 @@ export default function IconDrawer({
                 className={`flex min-h-11 min-w-11 items-center justify-center rounded font-mono text-[10px] transition-colors ${
                   previewSize === size
                     ? 'bg-accent/20 text-accent'
-                    : 'bg-white/5 text-white/50 hover:text-white/60'
+                    : 'bg-fg/5 text-fg/50 hover:text-fg/60'
                 }`}
               >
                 {size}
@@ -453,7 +453,7 @@ export default function IconDrawer({
 
         {/* Color control */}
         <div className="border-b border-border px-5 py-4">
-          <p className="mb-3 text-xs font-medium uppercase tracking-wide text-white/50">
+          <p className="mb-3 text-xs font-medium uppercase tracking-wide text-fg/50">
             Color
           </p>
           <div className="flex flex-wrap items-center gap-2">
@@ -466,7 +466,7 @@ export default function IconDrawer({
                 className={`h-11 w-11 rounded-full border-2 transition-all ${
                   previewColor === c.value
                     ? 'border-accent scale-110'
-                    : 'border-transparent hover:border-white/20'
+                    : 'border-transparent hover:border-fg/20'
                 }`}
                 style={
                   c.value
@@ -487,7 +487,7 @@ export default function IconDrawer({
                 className="absolute inset-0 h-11 w-11 cursor-pointer opacity-0"
                 aria-label="Custom color"
               />
-              <span className="flex h-11 w-11 items-center justify-center rounded-full border border-dashed border-white/20 text-white/50 transition-colors hover:border-white/40 hover:text-white/60">
+              <span className="flex h-11 w-11 items-center justify-center rounded-full border border-dashed border-fg/20 text-fg/50 transition-colors hover:border-fg/40 hover:text-fg/60">
                 <svg
                   viewBox="0 0 16 16"
                   className="h-3.5 w-3.5"
@@ -515,8 +515,8 @@ export default function IconDrawer({
                   onClick={() => setCodeTab(tab.key)}
                   className={`rounded-t-md px-3 py-1.5 text-xs font-medium transition-colors ${
                     effectiveTab === tab.key
-                      ? 'bg-surface text-white'
-                      : 'text-white/50 hover:text-white/60'
+                      ? 'bg-surface text-fg'
+                      : 'text-fg/50 hover:text-fg/60'
                   }`}
                 >
                   {tab.label}
@@ -525,7 +525,7 @@ export default function IconDrawer({
             </div>
             <CopyButton text={codeContent} />
           </div>
-          <pre className="overflow-x-auto rounded-b-lg rounded-tr-lg border border-border bg-surface p-4 font-mono text-sm text-white/80">
+          <pre className="overflow-x-auto rounded-b-lg rounded-tr-lg border border-border bg-surface p-4 font-mono text-sm text-fg/80">
             <code>{codeContent}</code>
           </pre>
 
@@ -533,7 +533,7 @@ export default function IconDrawer({
           <button
             type="button"
             onClick={() => downloadSvg(selected, iconRef.current)}
-            className="mt-4 flex w-full items-center justify-center gap-2 rounded-lg border border-border bg-surface py-2.5 text-sm font-medium text-white/60 transition-colors hover:bg-surface-hover hover:text-white"
+            className="mt-4 flex w-full items-center justify-center gap-2 rounded-lg border border-border bg-surface py-2.5 text-sm font-medium text-fg/60 transition-colors hover:bg-surface-hover hover:text-fg"
           >
             <svg
               viewBox="0 0 16 16"

--- a/example/src/components/elements/SearchForm.tsx
+++ b/example/src/components/elements/SearchForm.tsx
@@ -62,7 +62,7 @@ export default function SearchForm({
         ref={inputRef}
         type="search"
         id="search"
-        className="peer h-11 w-full rounded-lg border border-border bg-surface pl-10 pr-12 font-mono text-sm text-white placeholder-white/30 transition-colors focus:border-accent/60 focus:ring-1 focus:ring-accent/60"
+        className="peer h-11 w-full rounded-lg border border-border bg-surface pl-10 pr-12 font-mono text-sm text-fg placeholder-fg/30 transition-colors focus:border-accent/60 focus:ring-1 focus:ring-accent/60"
         placeholder="Search icons..."
         aria-describedby="icon-count"
         value={keyword}
@@ -77,7 +77,7 @@ export default function SearchForm({
         strokeLinejoin="round"
         width="1em"
         height="1em"
-        className="pointer-events-none absolute left-3 text-lg text-white/50 peer-focus:text-accent"
+        className="pointer-events-none absolute left-3 text-lg text-fg/50 peer-focus:text-accent"
         aria-hidden="true"
       >
         <circle cx={11} cy={11} r={8} />
@@ -85,12 +85,12 @@ export default function SearchForm({
       </svg>
       {keyword ? (
         <div className="pointer-events-none absolute right-3 flex items-center gap-2">
-          <span className="font-mono text-xs text-white/50">
+          <span className="font-mono text-xs text-fg/50">
             {resultCount}/{totalCount}
           </span>
         </div>
       ) : (
-        <kbd className="pointer-events-none absolute right-3 rounded border border-border bg-white/5 px-1.5 py-0.5 font-mono text-xs text-white/50 transition-opacity peer-focus:opacity-0">
+        <kbd className="pointer-events-none absolute right-3 rounded border border-border bg-fg/5 px-1.5 py-0.5 font-mono text-xs text-fg/50 transition-opacity peer-focus:opacity-0">
           /
         </kbd>
       )}

--- a/example/src/components/sections/CategoryBar.tsx
+++ b/example/src/components/sections/CategoryBar.tsx
@@ -66,7 +66,7 @@ export default function CategoryBar() {
   return (
     <nav
       aria-label="Icon categories"
-      className="scrollbar-none sticky top-0 z-10 overflow-x-auto border-b border-border bg-[#0a0a0a] px-4 py-2 sm:px-6"
+      className="theme-transition scrollbar-none sticky top-0 z-10 overflow-x-auto border-b border-border bg-bg-nav px-4 py-2 sm:px-6"
     >
       <div ref={containerRef} className="relative flex gap-1">
         {/* Animated indicator */}
@@ -83,8 +83,8 @@ export default function CategoryBar() {
               href={item === 'all' ? '/' : `/?category=${item}`}
               className={`shrink-0 rounded-md px-3 py-1.5 text-sm font-medium capitalize transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent ${
                 isActive
-                  ? 'text-white'
-                  : 'text-white/50 hover:bg-white/5 hover:text-white/70'
+                  ? 'text-fg'
+                  : 'text-fg/50 hover:bg-fg/5 hover:text-fg/70'
               }`}
               aria-current={isActive ? 'page' : undefined}
             >

--- a/example/src/components/sections/Footer.tsx
+++ b/example/src/components/sections/Footer.tsx
@@ -2,10 +2,10 @@ import pkg from '../../../../package.json';
 
 export default function Footer() {
   return (
-    <footer className="mt-auto border-t border-border px-4 py-4 sm:px-6">
-      <div className="flex items-center justify-between text-xs text-white/50">
+    <footer className="theme-transition mt-auto border-t border-border px-4 py-4 sm:px-6">
+      <div className="flex items-center justify-between text-xs text-fg/50">
         <div className="flex items-center gap-3">
-          <span className="font-medium text-white/60">React Web3 Icons</span>
+          <span className="font-medium text-fg/60">React Web3 Icons</span>
           <span className="font-mono">v{pkg.version}</span>
           <span>MIT</span>
         </div>
@@ -14,7 +14,7 @@ export default function Footer() {
             href="https://github.com/derodero24/react-web3-icons"
             target="_blank"
             rel="noopener noreferrer"
-            className="transition-colors hover:text-white/80"
+            className="transition-colors hover:text-fg/80"
           >
             GitHub
           </a>
@@ -22,7 +22,7 @@ export default function Footer() {
             href="https://www.npmjs.com/package/react-web3-icons"
             target="_blank"
             rel="noopener noreferrer"
-            className="transition-colors hover:text-white/80"
+            className="transition-colors hover:text-fg/80"
           >
             npm
           </a>

--- a/example/src/components/sections/Header.tsx
+++ b/example/src/components/sections/Header.tsx
@@ -6,29 +6,29 @@ import GitHubButton from '../elements/GitHubButton';
 
 export default function Header() {
   return (
-    <header className="flex items-center justify-between border-b border-border px-4 py-3 sm:px-6">
+    <header className="theme-transition flex items-center justify-between border-b border-border px-4 py-3 sm:px-6">
       <div className="flex items-baseline gap-2">
         <h1 className="text-lg font-semibold tracking-tight sm:text-xl">
           <Link href="/" className="transition-opacity hover:opacity-80">
             React Web3 Icons
           </Link>
         </h1>
-        <span className="font-mono text-xs text-white/50">v{pkg.version}</span>
+        <span className="font-mono text-xs text-fg/50">v{pkg.version}</span>
       </div>
       <nav aria-label="Site navigation" className="flex items-center gap-4">
         <Link
           href="/docs"
-          className="rounded text-sm font-medium text-white/60 transition-colors hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent"
+          className="rounded text-sm font-medium text-fg/60 transition-colors hover:text-fg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent"
         >
           Docs
         </Link>
         <Link
           href="/compare"
-          className="rounded text-sm font-medium text-white/60 transition-colors hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent"
+          className="rounded text-sm font-medium text-fg/60 transition-colors hover:text-fg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent"
         >
           Compare
         </Link>
-        <GitHubButton className="cursor-pointer text-2xl text-white/60 transition-colors hover:text-white focus-visible:rounded focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent" />
+        <GitHubButton className="cursor-pointer text-2xl text-fg/60 transition-colors hover:text-fg focus-visible:rounded focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent" />
       </nav>
     </header>
   );

--- a/example/src/components/sections/Hero.tsx
+++ b/example/src/components/sections/Hero.tsx
@@ -30,12 +30,12 @@ export default function Hero() {
   };
 
   return (
-    <section className="border-b border-border px-4 py-10 sm:px-6 sm:py-14">
+    <section className="theme-transition border-b border-border px-4 py-10 sm:px-6 sm:py-14">
       <div className="mx-auto max-w-2xl text-center">
-        <h2 className="text-2xl font-bold tracking-tight text-white sm:text-3xl">
+        <h2 className="text-2xl font-bold tracking-tight text-fg sm:text-3xl">
           {ICON_COUNT}+ Web3 icons for React
         </h2>
-        <p className="mt-3 text-sm text-white/50 sm:text-base">
+        <p className="mt-3 text-sm text-fg/50 sm:text-base">
           Open-source SVG icons for chains, coins, wallets, DEXs, and more.
         </p>
 
@@ -48,9 +48,7 @@ export default function Hero() {
                 type="button"
                 onClick={() => handlePkgChange(m)}
                 className={`rounded-md px-2.5 py-1 text-xs font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent ${
-                  pkg === m
-                    ? 'bg-white/10 text-white'
-                    : 'text-white/50 hover:text-white/60'
+                  pkg === m ? 'bg-fg/10 text-fg' : 'text-fg/50 hover:text-fg/60'
                 }`}
               >
                 {m}
@@ -61,10 +59,10 @@ export default function Hero() {
             type="button"
             onClick={() => copy(INSTALL_CMDS[pkg])}
             aria-label="Copy install command"
-            className="flex items-center gap-3 rounded-lg border border-border bg-surface px-5 py-2.5 font-mono text-sm text-white/80 transition-colors hover:bg-surface-hover"
+            className="flex items-center gap-3 rounded-lg border border-border bg-surface px-5 py-2.5 font-mono text-sm text-fg/80 transition-colors hover:bg-surface-hover"
           >
             <span className="select-all">{INSTALL_CMDS[pkg]}</span>
-            <span className="text-white/50">
+            <span className="text-fg/50">
               <CopyToggleIcon copied={copied} />
             </span>
           </button>

--- a/example/src/components/sections/IconTable.tsx
+++ b/example/src/components/sections/IconTable.tsx
@@ -1,11 +1,11 @@
 'use client';
 
 import { parseAsString, useQueryState } from 'nuqs';
-import type { CSSProperties } from 'react';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
 import * as iconModules from 'react-web3-icons';
 import { useIconFilter } from '../../hooks/useIconFilter';
+import { useTheme } from '../../hooks/useTheme';
 import type { IconComponent, Variant } from '../../types/icons';
 import { groupIcons } from '../../utils/groupIcons';
 import { REACT_WEB3_ICONS } from '../../utils/icons';
@@ -23,8 +23,6 @@ const VARIANTS: Variant[] = ['all', 'colored', 'mono'];
 
 const PAGE_SIZE = 120;
 
-type GridBg = 'dark' | 'light' | 'custom';
-
 export default function IconTable() {
   const [rawCategory] = useQueryState(
     'category',
@@ -39,9 +37,8 @@ export default function IconTable() {
     parseAsString.withDefault('').withOptions({ history: 'push' }),
   );
   const [variant, setVariant] = useState<Variant>('all');
-  const [gridBg, setGridBg] = useState<GridBg>('dark');
-  const [customColor, setCustomColor] = useState('#ffffff');
   const [visibleCount, setVisibleCount] = useState(PAGE_SIZE);
+  const { theme, toggleTheme } = useTheme();
 
   const validCategory = Object.hasOwn(REACT_WEB3_ICONS, rawCategory)
     ? (rawCategory as keyof typeof REACT_WEB3_ICONS)
@@ -151,15 +148,6 @@ export default function IconTable() {
     }
   }, [linkedIcon, setLinkedIcon]);
 
-  // Grid background styling
-  const isLightMode = gridBg !== 'dark';
-  const gridPanelStyle: CSSProperties | undefined =
-    gridBg === 'light'
-      ? { backgroundColor: '#ffffff' }
-      : gridBg === 'custom'
-        ? { backgroundColor: customColor }
-        : undefined;
-
   return (
     <section
       id="icon-grid"
@@ -188,8 +176,8 @@ export default function IconTable() {
                 aria-pressed={variant === v}
                 className={`h-11 px-4 text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-accent ${
                   variant === v
-                    ? 'bg-white/10 text-white'
-                    : 'text-white/50 hover:bg-white/5 hover:text-white/60'
+                    ? 'bg-fg/10 text-fg'
+                    : 'text-fg/50 hover:bg-fg/5 hover:text-fg/60'
                 }`}
               >
                 {VARIANT_LABELS[v]}
@@ -197,41 +185,15 @@ export default function IconTable() {
             ))}
           </fieldset>
 
-          <fieldset className="flex items-center gap-1 rounded-lg border border-border bg-surface px-1.5 py-1">
-            <legend className="sr-only">Grid background</legend>
-            {/* Dark button */}
-            <button
-              type="button"
-              onClick={() => setGridBg('dark')}
-              aria-label="Dark background"
-              aria-pressed={gridBg === 'dark'}
-              className={`flex h-8 w-8 items-center justify-center rounded transition-colors ${
-                gridBg === 'dark'
-                  ? 'bg-white/10 text-white'
-                  : 'text-white/40 hover:text-white/60'
-              }`}
-            >
-              <svg
-                viewBox="0 0 16 16"
-                className="h-4 w-4"
-                fill="currentColor"
-                aria-hidden="true"
-              >
-                <path d="M8 1a7 7 0 1 0 0 14A7 7 0 0 0 8 1Zm0 12.5a5.5 5.5 0 0 1 0-11v11Z" />
-              </svg>
-            </button>
-            {/* Light button */}
-            <button
-              type="button"
-              onClick={() => setGridBg('light')}
-              aria-label="Light background"
-              aria-pressed={gridBg === 'light'}
-              className={`flex h-8 w-8 items-center justify-center rounded transition-colors ${
-                gridBg === 'light'
-                  ? 'bg-white/10 text-white'
-                  : 'text-white/40 hover:text-white/60'
-              }`}
-            >
+          <button
+            type="button"
+            onClick={toggleTheme}
+            aria-label={
+              theme === 'dark' ? 'Switch to light mode' : 'Switch to dark mode'
+            }
+            className="flex h-11 w-11 items-center justify-center rounded-lg border border-border bg-surface text-fg/50 transition-colors hover:bg-surface-hover hover:text-fg/60"
+          >
+            {theme === 'dark' ? (
               <svg
                 viewBox="0 0 16 16"
                 className="h-4 w-4"
@@ -244,29 +206,17 @@ export default function IconTable() {
                 <circle cx={8} cy={8} r={3.5} />
                 <path d="M8 1.5v1M8 13.5v1M1.5 8h1M13.5 8h1M3.4 3.4l.7.7M11.9 11.9l.7.7M3.4 12.6l.7-.7M11.9 4.1l.7-.7" />
               </svg>
-            </button>
-            {/* Custom color picker */}
-            <label
-              className={`relative flex h-8 w-8 cursor-pointer items-center justify-center rounded transition-colors ${
-                gridBg === 'custom' ? 'ring-2 ring-accent ring-inset' : ''
-              }`}
-            >
-              <input
-                type="color"
-                value={customColor}
-                onChange={e => {
-                  setCustomColor(e.target.value);
-                  setGridBg('custom');
-                }}
-                className="absolute inset-0 cursor-pointer opacity-0"
-                aria-label="Custom background color"
-              />
-              <span
-                className="h-5 w-5 rounded-full border border-white/20"
-                style={{ backgroundColor: customColor }}
-              />
-            </label>
-          </fieldset>
+            ) : (
+              <svg
+                viewBox="0 0 16 16"
+                className="h-4 w-4"
+                fill="currentColor"
+                aria-hidden="true"
+              >
+                <path d="M8 1a7 7 0 1 0 0 14A7 7 0 0 0 8 1Zm0 12.5a5.5 5.5 0 0 1 0-11v11Z" />
+              </svg>
+            )}
+          </button>
         </div>
       </div>
 
@@ -275,7 +225,7 @@ export default function IconTable() {
       </p>
 
       {isCategoryEmpty ? (
-        <div className="mt-16 flex flex-col items-center gap-2 text-center text-white/50">
+        <div className="mt-16 flex flex-col items-center gap-2 text-center text-fg/50">
           <svg
             viewBox="0 0 24 24"
             fill="none"
@@ -289,13 +239,13 @@ export default function IconTable() {
             <circle cx={12} cy={12} r={10} />
             <path d="M8 12h8" />
           </svg>
-          <p className="text-base font-medium text-white/50">No icons yet</p>
+          <p className="text-base font-medium text-fg/50">No icons yet</p>
           <p className="text-sm">
             {`${validCategory.charAt(0).toUpperCase()}${validCategory.slice(1)} icons are coming soon`}
           </p>
         </div>
       ) : isSearchEmpty ? (
-        <div className="mt-16 flex flex-col items-center gap-2 text-center text-white/50">
+        <div className="mt-16 flex flex-col items-center gap-2 text-center text-fg/50">
           <svg
             viewBox="0 0 24 24"
             fill="none"
@@ -309,19 +259,16 @@ export default function IconTable() {
             <circle cx={11} cy={11} r={8} />
             <path d="m21 21-4.35-4.35" />
           </svg>
-          <p className="text-base font-medium text-white/50">
+          <p className="text-base font-medium text-fg/50">
             No results for &ldquo;{keyword}&rdquo;
           </p>
           <p className="text-sm">Try a different search term</p>
         </div>
       ) : (
-        <div
-          className={`mt-6 rounded-xl transition-colors duration-200 ${isLightMode ? 'p-2' : ''}`}
-          style={gridPanelStyle}
-        >
+        <>
           <ul
             key={`${validCategory}-${variant}`}
-            className="grid list-none grid-cols-[repeat(auto-fill,minmax(88px,1fr))] gap-0 sm:grid-cols-[repeat(auto-fill,minmax(112px,1fr))]"
+            className="mt-6 grid list-none grid-cols-[repeat(auto-fill,minmax(88px,1fr))] gap-0 sm:grid-cols-[repeat(auto-fill,minmax(112px,1fr))]"
           >
             {visibleGroups.map(group => (
               <li key={group.base} data-icon-name={group.base} className="p-2">
@@ -330,7 +277,6 @@ export default function IconTable() {
                   activeVariant={group.activeVariant}
                   components={group.components}
                   highlighted={linkedIcon === group.base}
-                  lightMode={isLightMode}
                   onClick={() => handleOpenDrawer(group.base)}
                 />
               </li>
@@ -342,10 +288,10 @@ export default function IconTable() {
               className="flex justify-center py-8"
               aria-hidden="true"
             >
-              <div className="h-6 w-6 animate-spin rounded-full border-2 border-white/10 border-t-accent" />
+              <div className="h-6 w-6 animate-spin rounded-full border-2 border-fg/10 border-t-accent" />
             </div>
           )}
-        </div>
+        </>
       )}
 
       {/* Detail drawer */}

--- a/example/src/hooks/useTheme.tsx
+++ b/example/src/hooks/useTheme.tsx
@@ -31,16 +31,16 @@ export function ThemeProvider({ children }: { children: ReactNode }) {
     const saved = localStorage.getItem(STORAGE_KEY);
     if (saved === 'light' || saved === 'dark') {
       setTheme(saved);
-      document.documentElement.dataset.theme = saved;
+      document.documentElement.dataset['theme'] = saved;
     }
   }, []);
 
   // Apply data-theme attribute when theme changes
   useEffect(() => {
     if (theme === 'light') {
-      document.documentElement.dataset.theme = 'light';
+      document.documentElement.dataset['theme'] = 'light';
     } else {
-      delete document.documentElement.dataset.theme;
+      delete document.documentElement.dataset['theme'];
     }
     localStorage.setItem(STORAGE_KEY, theme);
   }, [theme]);

--- a/example/src/hooks/useTheme.tsx
+++ b/example/src/hooks/useTheme.tsx
@@ -1,0 +1,61 @@
+'use client';
+
+import {
+  createContext,
+  type ReactNode,
+  useCallback,
+  useContext,
+  useEffect,
+  useState,
+} from 'react';
+
+type Theme = 'dark' | 'light';
+
+interface ThemeContextValue {
+  theme: Theme;
+  toggleTheme: () => void;
+}
+
+const ThemeContext = createContext<ThemeContextValue>({
+  theme: 'dark',
+  toggleTheme: () => {},
+});
+
+const STORAGE_KEY = 'rw3i-theme';
+
+export function ThemeProvider({ children }: { children: ReactNode }) {
+  const [theme, setTheme] = useState<Theme>('dark');
+
+  // Restore saved theme on mount
+  useEffect(() => {
+    const saved = localStorage.getItem(STORAGE_KEY);
+    if (saved === 'light' || saved === 'dark') {
+      setTheme(saved);
+      document.documentElement.dataset.theme = saved;
+    }
+  }, []);
+
+  // Apply data-theme attribute when theme changes
+  useEffect(() => {
+    if (theme === 'light') {
+      document.documentElement.dataset.theme = 'light';
+    } else {
+      delete document.documentElement.dataset.theme;
+    }
+    localStorage.setItem(STORAGE_KEY, theme);
+  }, [theme]);
+
+  const toggleTheme = useCallback(() => {
+    setTheme(prev => (prev === 'dark' ? 'light' : 'dark'));
+  }, []);
+
+  return (
+    <ThemeContext.Provider value={{ theme, toggleTheme }}>
+      {children}
+    </ThemeContext.Provider>
+  );
+}
+
+export function useTheme() {
+  return useContext(ThemeContext);
+}

--- a/example/src/styles/global.css
+++ b/example/src/styles/global.css
@@ -8,11 +8,14 @@
     "JetBrains Mono", ui-monospace, "Cascadia Code", "Source Code Pro", "Menlo",
     "Consolas", "DejaVu Sans Mono", monospace;
 
-  --color-surface: #111111;
-  --color-surface-hover: #1a1a1a;
-  --color-border: #222222;
+  --color-bg: #0f0f0f;
+  --color-bg-nav: #121212;
+  --color-surface: #181818;
+  --color-surface-hover: #222222;
+  --color-border: #2a2a2a;
   --color-accent: #6366f1;
   --color-accent-hover: #818cf8;
+  --color-fg: #ffffff;
 }
 
 @layer base {
@@ -22,8 +25,17 @@
 
   html,
   body {
-    @apply bg-[#080808] text-white;
+    @apply bg-bg text-fg;
     -webkit-tap-highlight-color: transparent;
+  }
+
+  html[data-theme="light"] {
+    --color-bg: #ffffff;
+    --color-bg-nav: #f9f9f9;
+    --color-surface: #f3f3f5;
+    --color-surface-hover: #eaeaed;
+    --color-border: #e0e0e3;
+    --color-fg: #111111;
   }
 
   input {
@@ -61,6 +73,13 @@
     }
   }
 
+  .theme-transition {
+    transition:
+      background-color 300ms ease,
+      color 300ms ease,
+      border-color 300ms ease;
+  }
+
   input[type="range"] {
     &::-webkit-slider-thumb {
       @apply h-3.5 w-3.5 appearance-none rounded-full bg-accent;
@@ -70,10 +89,10 @@
       @apply h-3.5 w-3.5 appearance-none rounded-full border-none bg-accent;
     }
     &::-webkit-slider-runnable-track {
-      @apply h-1.5 rounded-full bg-white/10;
+      @apply h-1.5 rounded-full bg-fg/10;
     }
     &::-moz-range-track {
-      @apply h-1.5 rounded-full bg-white/10;
+      @apply h-1.5 rounded-full bg-fg/10;
     }
   }
 }


### PR DESCRIPTION
## Summary

- Replace partial grid-only background toggle (#659) with a proper page-wide dark/light theme system
- Define theme tokens (`bg`, `bg-nav`, `surface`, `border`, `fg`) via CSS custom properties with `[data-theme="light"]` overrides
- Add `ThemeProvider` context with `localStorage` persistence
- Replace all hardcoded `text-white`, `bg-white/XX` classes with theme-aware `text-fg`, `bg-fg/XX` tokens across all components
- Slightly brighten the dark palette base (`#0f0f0f` vs old `#080808`) for better border/card visibility
- Smooth animated transition between modes via `theme-transition` utility class
- Simplify toolbar to a single sun/moon toggle button (removed custom color picker)

## Related issue

Closes #660

## Checklist

- [x] `pnpm run check` passes
- [x] `pnpm run typecheck` passes
- [x] Visual verification: dark mode, light mode, toggle animation, scrolling — all confirmed via Chrome DevTools
- [x] Theme persists across page reloads (localStorage)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **新機能**
  * ダーク/ライトのテーマ管理と切替UIを追加しました。選択はローカルに保存され自動復元されます。

* **スタイル**
  * 全体の色トークンを整理し、前景ベースの配色に統一しました。
  * 多数のコンポーネントでテーマ対応の色に更新しました（ヘッダー、フッター、検索、アイコン一覧等）。
  * テーマ切替時のスムーズなトランジションを導入しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->