### PR TITLE
Fix theme transition desync and add theme support to all pages

### DIFF
--- a/example/next-env.d.ts
+++ b/example/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/types/routes.d.ts";
+import "./.next/dev/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/example/src/app/compare/page.tsx
+++ b/example/src/app/compare/page.tsx
@@ -19,7 +19,7 @@ function Section({
 }) {
   return (
     <section id={id} className="scroll-mt-8">
-      <h2 className="mb-4 text-xl font-semibold text-white">{title}</h2>
+      <h2 className="mb-4 text-xl font-semibold text-fg">{title}</h2>
       {children}
     </section>
   );
@@ -47,7 +47,7 @@ function CrossIcon() {
     <svg
       viewBox="0 0 20 20"
       fill="currentColor"
-      className="mx-auto h-4 w-4 text-white/30"
+      className="mx-auto h-4 w-4 text-fg/30"
       aria-label="No"
     >
       <path
@@ -218,13 +218,11 @@ const COMPARISON_ROWS: {
   },
   {
     feature: 'Icon count',
-    ours: <span className="text-sm text-white/70">~250</span>,
+    ours: <span className="text-sm text-fg/70">~250</span>,
     competitors: {
-      web3icons: <span className="text-sm text-white/70">2,500+</span>,
-      'cryptocurrency-icons': (
-        <span className="text-sm text-white/70">~500</span>
-      ),
-      ledger: <span className="text-sm text-white/70">CDN-based</span>,
+      web3icons: <span className="text-sm text-fg/70">2,500+</span>,
+      'cryptocurrency-icons': <span className="text-sm text-fg/70">~500</span>,
+      ledger: <span className="text-sm text-fg/70">CDN-based</span>,
     },
   },
 ];
@@ -234,12 +232,12 @@ export default function ComparePage() {
     <div className="mx-auto max-w-5xl px-4 py-8 sm:px-6 lg:px-8">
       <div className="lg:grid lg:grid-cols-[1fr_200px] lg:gap-8">
         <div>
-          <h1 className="mb-2 text-3xl font-bold text-white">
+          <h1 className="mb-2 text-3xl font-bold text-fg">
             Library Comparison
           </h1>
-          <p className="mb-10 text-white/50">
+          <p className="mb-10 text-fg/50">
             How{' '}
-            <code className="rounded bg-surface px-1 py-0.5 font-mono text-sm text-white/60">
+            <code className="rounded bg-surface px-1 py-0.5 font-mono text-sm text-fg/60">
               react-web3-icons
             </code>{' '}
             compares to other Web3 / cryptocurrency icon libraries.
@@ -248,15 +246,15 @@ export default function ComparePage() {
           <div className="flex flex-col gap-10">
             {/* Overview */}
             <Section id="overview" title="Overview">
-              <p className="mb-4 text-sm text-white/60">
+              <p className="mb-4 text-sm text-fg/60">
                 Several libraries provide cryptocurrency and Web3 icons. They
                 differ in scope, API design, and maintenance status:
               </p>
-              <ul className="mb-4 flex flex-col gap-3 text-sm text-white/60">
+              <ul className="mb-4 flex flex-col gap-3 text-sm text-fg/60">
                 <li className="flex gap-2">
                   <span className="mt-0.5 shrink-0 text-accent">→</span>
                   <span>
-                    <strong className="font-medium text-white/80">
+                    <strong className="font-medium text-fg/80">
                       react-web3-icons
                     </strong>{' '}
                     prioritises a lean, production-ready bundle with
@@ -267,7 +265,7 @@ export default function ComparePage() {
                 <li className="flex gap-2">
                   <span className="mt-0.5 shrink-0 text-accent">→</span>
                   <span>
-                    <strong className="font-medium text-white/80">
+                    <strong className="font-medium text-fg/80">
                       @web3icons/react
                     </strong>{' '}
                     offers a much larger catalogue (2,500+ icons), a raw SVG
@@ -277,7 +275,7 @@ export default function ComparePage() {
                 <li className="flex gap-2">
                   <span className="mt-0.5 shrink-0 text-accent">→</span>
                   <span>
-                    <strong className="font-medium text-white/80">
+                    <strong className="font-medium text-fg/80">
                       cryptocurrency-icons
                     </strong>{' '}
                     (spothq) is a framework-agnostic SVG/PNG asset pack with
@@ -288,7 +286,7 @@ export default function ComparePage() {
                 <li className="flex gap-2">
                   <span className="mt-0.5 shrink-0 text-accent">→</span>
                   <span>
-                    <strong className="font-medium text-white/80">
+                    <strong className="font-medium text-fg/80">
                       @ledgerhq/crypto-icons
                     </strong>{' '}
                     is a Ledger-ecosystem React component that fetches icons
@@ -301,7 +299,7 @@ export default function ComparePage() {
 
             {/* Bundle Size */}
             <Section id="bundle-size" title="Bundle Size">
-              <p className="mb-4 text-sm text-white/60">
+              <p className="mb-4 text-sm text-fg/60">
                 Because both libraries ship ES modules, your bundler tree-shakes
                 unused icons automatically. The numbers below reflect
                 gzip-compressed size for a handful of representative import
@@ -315,13 +313,13 @@ export default function ComparePage() {
                   </caption>
                   <thead>
                     <tr className="border-b border-border bg-surface">
-                      <th className="py-2 pr-4 pl-3 text-xs font-semibold uppercase tracking-wide text-white/50">
+                      <th className="py-2 pr-4 pl-3 text-xs font-semibold uppercase tracking-wide text-fg/50">
                         Import
                       </th>
-                      <th className="py-2 pr-4 text-right text-xs font-semibold uppercase tracking-wide text-white/50">
+                      <th className="py-2 pr-4 text-right text-xs font-semibold uppercase tracking-wide text-fg/50">
                         Raw
                       </th>
-                      <th className="py-2 pr-4 text-right text-xs font-semibold uppercase tracking-wide text-white/50">
+                      <th className="py-2 pr-4 text-right text-xs font-semibold uppercase tracking-wide text-fg/50">
                         Gzip
                       </th>
                     </tr>
@@ -355,13 +353,13 @@ export default function ComparePage() {
                       },
                     ].map(row => (
                       <tr key={row.label}>
-                        <td className="py-2 pr-4 pl-3 font-mono text-sm text-white/70">
+                        <td className="py-2 pr-4 pl-3 font-mono text-sm text-fg/70">
                           {row.label}
                         </td>
-                        <td className="py-2 pr-4 text-right font-mono text-sm text-white/50">
+                        <td className="py-2 pr-4 text-right font-mono text-sm text-fg/50">
                           {row.raw}
                         </td>
-                        <td className="py-2 pr-4 text-right font-mono text-sm text-white/50">
+                        <td className="py-2 pr-4 text-right font-mono text-sm text-fg/50">
                           {row.gzip}
                         </td>
                       </tr>
@@ -370,7 +368,7 @@ export default function ComparePage() {
                 </table>
               </div>
 
-              <p className="text-sm text-white/40">
+              <p className="text-sm text-fg/40">
                 Measured with{' '}
                 <code className="rounded bg-surface px-1 font-mono text-xs">
                   size-limit
@@ -382,11 +380,11 @@ export default function ComparePage() {
 
             {/* API Comparison */}
             <Section id="api" title="API Comparison">
-              <p className="mb-4 text-sm text-white/60">
+              <p className="mb-4 text-sm text-fg/60">
                 Each library takes a different approach to exposing icons:
               </p>
 
-              <h3 className="mb-2 mt-6 text-sm font-semibold text-white/80">
+              <h3 className="mb-2 mt-6 text-sm font-semibold text-fg/80">
                 react-web3-icons
               </h3>
               <CodeBlock>{`// Named import — fully tree-shakeable
@@ -405,7 +403,7 @@ import { ChainIcon } from 'react-web3-icons/dynamic';
 import { CHAIN_ID_TO_NAME } from 'react-web3-icons/meta';
 const name = CHAIN_ID_TO_NAME[1]; // "Ethereum"`}</CodeBlock>
 
-              <h3 className="mb-2 mt-6 text-sm font-semibold text-white/80">
+              <h3 className="mb-2 mt-6 text-sm font-semibold text-fg/80">
                 @web3icons/react
               </h3>
               <CodeBlock>{`// Named import with variant prop
@@ -415,7 +413,7 @@ import { IconEthereum } from '@web3icons/react';
 <IconEthereum size={32} variant="mono" />
 <IconEthereum size={32} variant="background" />`}</CodeBlock>
 
-              <h3 className="mb-2 mt-6 text-sm font-semibold text-white/80">
+              <h3 className="mb-2 mt-6 text-sm font-semibold text-fg/80">
                 cryptocurrency-icons
               </h3>
               <CodeBlock>{`// Asset-only — no React components, just file paths
@@ -424,7 +422,7 @@ import btcPng from 'cryptocurrency-icons/128/color/btc.png';
 
 <img src={ethSvg} alt="Ethereum" width={32} height={32} />`}</CodeBlock>
 
-              <h3 className="mb-2 mt-6 text-sm font-semibold text-white/80">
+              <h3 className="mb-2 mt-6 text-sm font-semibold text-fg/80">
                 @ledgerhq/crypto-icons
               </h3>
               <CodeBlock>{`// Single dynamic component — fetches from Ledger CDN
@@ -433,7 +431,7 @@ import { CryptoIcon } from '@ledgerhq/crypto-icons';
 <CryptoIcon ledgerId="ethereum" size={32} />
 // Falls back to CoinGecko mapping, then letter icon`}</CodeBlock>
 
-              <p className="mt-4 text-sm text-white/60">
+              <p className="mt-4 text-sm text-fg/60">
                 Key differences:{' '}
                 <code className="rounded bg-surface px-1 font-mono text-sm">
                   react-web3-icons
@@ -475,21 +473,21 @@ import { CryptoIcon } from '@ledgerhq/crypto-icons';
                   </caption>
                   <thead>
                     <tr className="border-b border-border bg-surface">
-                      <th className="py-2 pr-4 pl-3 text-xs font-semibold uppercase tracking-wide text-white/50">
+                      <th className="py-2 pr-4 pl-3 text-xs font-semibold uppercase tracking-wide text-fg/50">
                         Feature
                       </th>
-                      <th className="py-2 pr-4 text-center text-xs font-semibold uppercase tracking-wide text-white/50">
+                      <th className="py-2 pr-4 text-center text-xs font-semibold uppercase tracking-wide text-fg/50">
                         react-web3-icons
                       </th>
                       {COMPETITORS.map(c => (
                         <th
                           key={c.key}
-                          className="py-2 pr-4 text-center text-xs font-semibold uppercase tracking-wide text-white/50"
+                          className="py-2 pr-4 text-center text-xs font-semibold uppercase tracking-wide text-fg/50"
                         >
                           {c.label}
                         </th>
                       ))}
-                      <th className="hidden py-2 pr-4 text-xs font-semibold uppercase tracking-wide text-white/50 xl:table-cell">
+                      <th className="hidden py-2 pr-4 text-xs font-semibold uppercase tracking-wide text-fg/50 xl:table-cell">
                         Note
                       </th>
                     </tr>
@@ -497,7 +495,7 @@ import { CryptoIcon } from '@ledgerhq/crypto-icons';
                   <tbody className="divide-y divide-border">
                     {COMPARISON_ROWS.map(row => (
                       <tr key={row.feature}>
-                        <td className="py-2.5 pr-4 pl-3 text-sm text-white/70">
+                        <td className="py-2.5 pr-4 pl-3 text-sm text-fg/70">
                           {row.feature}
                         </td>
                         <td className="py-2.5 pr-4 text-center">{row.ours}</td>
@@ -506,7 +504,7 @@ import { CryptoIcon } from '@ledgerhq/crypto-icons';
                             {row.competitors[c.key]}
                           </td>
                         ))}
-                        <td className="hidden py-2.5 pr-4 text-sm text-white/40 xl:table-cell">
+                        <td className="hidden py-2.5 pr-4 text-sm text-fg/40 xl:table-cell">
                           {row.note ?? ''}
                         </td>
                       </tr>
@@ -515,13 +513,13 @@ import { CryptoIcon } from '@ledgerhq/crypto-icons';
                 </table>
               </div>
 
-              <p className="mt-4 text-sm text-white/40">
+              <p className="mt-4 text-sm text-fg/40">
                 Sources:{' '}
                 <a
                   href="https://github.com/0xa3k5/web3icons"
                   target="_blank"
                   rel="noopener noreferrer"
-                  className="underline hover:text-white/60"
+                  className="underline hover:text-fg/60"
                 >
                   @web3icons/react
                 </a>
@@ -530,7 +528,7 @@ import { CryptoIcon } from '@ledgerhq/crypto-icons';
                   href="https://github.com/spothq/cryptocurrency-icons"
                   target="_blank"
                   rel="noopener noreferrer"
-                  className="underline hover:text-white/60"
+                  className="underline hover:text-fg/60"
                 >
                   cryptocurrency-icons
                 </a>
@@ -539,7 +537,7 @@ import { CryptoIcon } from '@ledgerhq/crypto-icons';
                   href="https://github.com/LedgerHQ/crypto-icons"
                   target="_blank"
                   rel="noopener noreferrer"
-                  className="underline hover:text-white/60"
+                  className="underline hover:text-fg/60"
                 >
                   @ledgerhq/crypto-icons
                 </a>
@@ -548,7 +546,7 @@ import { CryptoIcon } from '@ledgerhq/crypto-icons';
                   href="https://npmtrends.com/react-web3-icons-vs-@web3icons/react-vs-cryptocurrency-icons-vs-@ledgerhq/crypto-icons"
                   target="_blank"
                   rel="noopener noreferrer"
-                  className="underline hover:text-white/60"
+                  className="underline hover:text-fg/60"
                 >
                   npm trends
                 </a>{' '}
@@ -561,7 +559,7 @@ import { CryptoIcon } from '@ledgerhq/crypto-icons';
         {/* Sticky sidebar TOC (desktop only) */}
         <aside className="hidden lg:block">
           <nav aria-label="Table of contents" className="sticky top-8">
-            <p className="mb-3 text-xs font-medium uppercase tracking-wide text-white/50">
+            <p className="mb-3 text-xs font-medium uppercase tracking-wide text-fg/50">
               On this page
             </p>
             <ul className="flex flex-col gap-1.5 border-l border-border pl-3">
@@ -569,7 +567,7 @@ import { CryptoIcon } from '@ledgerhq/crypto-icons';
                 <li key={item.id}>
                   <a
                     href={`#${item.id}`}
-                    className="text-sm text-white/50 transition-colors hover:text-white/80"
+                    className="text-sm text-fg/50 transition-colors hover:text-fg/80"
                   >
                     {item.label}
                   </a>

--- a/example/src/app/docs/page.tsx
+++ b/example/src/app/docs/page.tsx
@@ -18,7 +18,7 @@ function Section({
 }) {
   return (
     <section id={id} className="scroll-mt-8">
-      <h2 className="mb-4 text-xl font-semibold text-white">{title}</h2>
+      <h2 className="mb-4 text-xl font-semibold text-fg">{title}</h2>
       {children}
     </section>
   );
@@ -40,10 +40,10 @@ export default function DocsPage() {
     <div className="mx-auto max-w-5xl px-4 py-8 sm:px-6 lg:px-8">
       <div className="lg:grid lg:grid-cols-[1fr_200px] lg:gap-8">
         <div>
-          <h1 className="mb-2 text-3xl font-bold text-white">API Reference</h1>
-          <p className="mb-10 text-white/50">
+          <h1 className="mb-2 text-3xl font-bold text-fg">API Reference</h1>
+          <p className="mb-10 text-fg/50">
             Usage guide and complete API reference for{' '}
-            <code className="rounded bg-surface px-1 py-0.5 font-mono text-sm text-white/60">
+            <code className="rounded bg-surface px-1 py-0.5 font-mono text-sm text-fg/60">
               react-web3-icons
             </code>
             .
@@ -52,7 +52,7 @@ export default function DocsPage() {
           <div className="flex flex-col gap-10">
             {/* Getting Started */}
             <Section id="getting-started" title="Getting Started">
-              <p className="mb-3 text-sm text-white/60">
+              <p className="mb-3 text-sm text-fg/60">
                 Install via your package manager:
               </p>
               <CodeBlock>{`npm install react-web3-icons
@@ -60,7 +60,7 @@ export default function DocsPage() {
 pnpm add react-web3-icons
 # or
 yarn add react-web3-icons`}</CodeBlock>
-              <p className="mt-4 mb-3 text-sm text-white/60">
+              <p className="mt-4 mb-3 text-sm text-fg/60">
                 Import and use any icon component:
               </p>
               <CodeBlock>{`import { Ethereum, BitcoinCircle, MetaMask } from 'react-web3-icons';
@@ -78,7 +78,7 @@ export function MyComponent() {
 
             {/* Icon Props */}
             <Section id="icon-props" title="Icon Props">
-              <p className="mb-4 text-sm text-white/60">
+              <p className="mb-4 text-sm text-fg/60">
                 All icon components accept the following props in addition to
                 standard SVG attributes.
               </p>
@@ -87,16 +87,16 @@ export function MyComponent() {
                   <caption className="sr-only">Icon component props</caption>
                   <thead>
                     <tr className="border-b border-border bg-surface">
-                      <th className="py-2 pr-4 pl-3 text-xs font-semibold uppercase tracking-wide text-white/50">
+                      <th className="py-2 pr-4 pl-3 text-xs font-semibold uppercase tracking-wide text-fg/50">
                         Prop
                       </th>
-                      <th className="py-2 pr-4 text-xs font-semibold uppercase tracking-wide text-white/50">
+                      <th className="py-2 pr-4 text-xs font-semibold uppercase tracking-wide text-fg/50">
                         Type
                       </th>
-                      <th className="py-2 pr-4 text-xs font-semibold uppercase tracking-wide text-white/50">
+                      <th className="py-2 pr-4 text-xs font-semibold uppercase tracking-wide text-fg/50">
                         Default
                       </th>
-                      <th className="py-2 text-xs font-semibold uppercase tracking-wide text-white/50">
+                      <th className="py-2 text-xs font-semibold uppercase tracking-wide text-fg/50">
                         Description
                       </th>
                     </tr>
@@ -106,13 +106,13 @@ export function MyComponent() {
                       <td className="py-2 pr-4 pl-3 align-top font-mono text-sm text-accent">
                         size
                       </td>
-                      <td className="py-2 pr-4 align-top font-mono text-sm text-white/60">
+                      <td className="py-2 pr-4 align-top font-mono text-sm text-fg/60">
                         {'string | number'}
                       </td>
-                      <td className="py-2 pr-4 align-top font-mono text-sm text-white/50">
+                      <td className="py-2 pr-4 align-top font-mono text-sm text-fg/50">
                         {'"1em"'}
                       </td>
-                      <td className="py-2 align-top text-sm text-white/60">
+                      <td className="py-2 align-top text-sm text-fg/60">
                         Sets both{' '}
                         <code className="rounded bg-surface px-1">width</code>{' '}
                         and{' '}
@@ -125,13 +125,13 @@ export function MyComponent() {
                       <td className="py-2 pr-4 pl-3 align-top font-mono text-sm text-accent">
                         className
                       </td>
-                      <td className="py-2 pr-4 align-top font-mono text-sm text-white/60">
+                      <td className="py-2 pr-4 align-top font-mono text-sm text-fg/60">
                         string
                       </td>
-                      <td className="py-2 pr-4 align-top font-mono text-sm text-white/50">
+                      <td className="py-2 pr-4 align-top font-mono text-sm text-fg/50">
                         —
                       </td>
-                      <td className="py-2 align-top text-sm text-white/60">
+                      <td className="py-2 align-top text-sm text-fg/60">
                         CSS class applied to the root{' '}
                         <code className="rounded bg-surface px-1">
                           {'<svg>'}
@@ -149,13 +149,13 @@ export function MyComponent() {
                       <td className="py-2 pr-4 pl-3 align-top font-mono text-sm text-accent">
                         title
                       </td>
-                      <td className="py-2 pr-4 align-top font-mono text-sm text-white/60">
+                      <td className="py-2 pr-4 align-top font-mono text-sm text-fg/60">
                         string
                       </td>
-                      <td className="py-2 pr-4 align-top font-mono text-sm text-white/50">
+                      <td className="py-2 pr-4 align-top font-mono text-sm text-fg/50">
                         —
                       </td>
-                      <td className="py-2 align-top text-sm text-white/60">
+                      <td className="py-2 align-top text-sm text-fg/60">
                         Accessible label rendered as a{' '}
                         <code className="rounded bg-surface px-1">
                           {'<title>'}
@@ -171,13 +171,13 @@ export function MyComponent() {
                       <td className="py-2 pr-4 pl-3 align-top font-mono text-sm text-accent">
                         titleId
                       </td>
-                      <td className="py-2 pr-4 align-top font-mono text-sm text-white/60">
+                      <td className="py-2 pr-4 align-top font-mono text-sm text-fg/60">
                         string
                       </td>
-                      <td className="py-2 pr-4 align-top font-mono text-sm text-white/50">
+                      <td className="py-2 pr-4 align-top font-mono text-sm text-fg/50">
                         —
                       </td>
-                      <td className="py-2 align-top text-sm text-white/60">
+                      <td className="py-2 align-top text-sm text-fg/60">
                         Optional ID for the{' '}
                         <code className="rounded bg-surface px-1">
                           {'<title>'}
@@ -197,13 +197,13 @@ export function MyComponent() {
                       <td className="py-2 pr-4 pl-3 align-top font-mono text-sm text-accent">
                         aria-hidden
                       </td>
-                      <td className="py-2 pr-4 align-top font-mono text-sm text-white/60">
+                      <td className="py-2 pr-4 align-top font-mono text-sm text-fg/60">
                         boolean
                       </td>
-                      <td className="py-2 pr-4 align-top font-mono text-sm text-white/50">
+                      <td className="py-2 pr-4 align-top font-mono text-sm text-fg/50">
                         true
                       </td>
-                      <td className="py-2 align-top text-sm text-white/60">
+                      <td className="py-2 align-top text-sm text-fg/60">
                         Defaults to{' '}
                         <code className="rounded bg-surface px-1">true</code>{' '}
                         (decorative). Set to{' '}
@@ -217,13 +217,13 @@ export function MyComponent() {
                       <td className="py-2 pr-4 pl-3 align-top font-mono text-sm text-accent">
                         style
                       </td>
-                      <td className="py-2 pr-4 align-top font-mono text-sm text-white/60">
+                      <td className="py-2 pr-4 align-top font-mono text-sm text-fg/60">
                         CSSProperties
                       </td>
-                      <td className="py-2 pr-4 align-top font-mono text-sm text-white/50">
+                      <td className="py-2 pr-4 align-top font-mono text-sm text-fg/50">
                         —
                       </td>
-                      <td className="py-2 align-top text-sm text-white/60">
+                      <td className="py-2 align-top text-sm text-fg/60">
                         Inline styles merged (shallow spread) on top of any{' '}
                         <code className="rounded bg-surface px-1">
                           IconContext
@@ -238,7 +238,7 @@ export function MyComponent() {
 
             {/* IconContext */}
             <Section id="icon-context" title="IconContext">
-              <p className="mb-3 text-sm text-white/60">
+              <p className="mb-3 text-sm text-fg/60">
                 Wrap a subtree with{' '}
                 <code className="rounded bg-surface px-1 font-mono text-sm">
                   IconContext.Provider
@@ -253,7 +253,7 @@ export function MyComponent() {
   <Ethereum />      {/* size=24, text-gray-700 */}
   <Bitcoin size={48} /> {/* size=48 (overrides context), text-gray-700 */}
 </IconContext.Provider>`}</CodeBlock>
-              <p className="mt-4 mb-3 text-sm text-white/60">
+              <p className="mt-4 mb-3 text-sm text-fg/60">
                 Context value accepts all{' '}
                 <a
                   href="#icon-props"
@@ -267,18 +267,18 @@ export function MyComponent() {
 
             {/* Import Patterns */}
             <Section id="import-patterns" title="Import Patterns">
-              <p className="mb-3 text-sm text-white/60">
+              <p className="mb-3 text-sm text-fg/60">
                 Two ways to import icons:
               </p>
               <div className="flex flex-col gap-4">
                 <div>
-                  <p className="mb-1.5 text-sm font-medium text-white/80">
+                  <p className="mb-1.5 text-sm font-medium text-fg/80">
                     Named import from root entry
                   </p>
                   <CodeBlock>{`import { Ethereum, BitcoinMono } from 'react-web3-icons';`}</CodeBlock>
                 </div>
                 <div>
-                  <p className="mb-1.5 text-sm font-medium text-white/80">
+                  <p className="mb-1.5 text-sm font-medium text-fg/80">
                     Category subpath (better tree-shaking)
                   </p>
                   <CodeBlock>{`import { Ethereum } from 'react-web3-icons/chain';
@@ -286,7 +286,7 @@ import { Bitcoin, Doge } from 'react-web3-icons/coin';
 import { MetaMask } from 'react-web3-icons/wallet';`}</CodeBlock>
                 </div>
                 <div>
-                  <p className="mb-1.5 text-sm font-medium text-white/80">
+                  <p className="mb-1.5 text-sm font-medium text-fg/80">
                     Available subpath categories
                   </p>
                   <CodeBlock>{`react-web3-icons/bridge
@@ -310,7 +310,7 @@ react-web3-icons/wallet`}</CodeBlock>
 
             {/* Naming Conventions */}
             <Section id="naming" title="Naming Conventions">
-              <p className="mb-4 text-sm text-white/60">
+              <p className="mb-4 text-sm text-fg/60">
                 Icon names use PascalCase. Variant suffixes describe visual
                 differences:
               </p>
@@ -321,10 +321,10 @@ react-web3-icons/wallet`}</CodeBlock>
                   </caption>
                   <thead>
                     <tr className="border-b border-border bg-surface">
-                      <th className="py-2 pr-4 pl-3 text-xs font-semibold uppercase tracking-wide text-white/50">
+                      <th className="py-2 pr-4 pl-3 text-xs font-semibold uppercase tracking-wide text-fg/50">
                         Suffix
                       </th>
-                      <th className="py-2 text-xs font-semibold uppercase tracking-wide text-white/50">
+                      <th className="py-2 text-xs font-semibold uppercase tracking-wide text-fg/50">
                         Description
                       </th>
                     </tr>
@@ -361,7 +361,7 @@ react-web3-icons/wallet`}</CodeBlock>
                         <td className="py-2 pr-4 pl-3 align-top font-mono text-sm text-accent">
                           {suffix}
                         </td>
-                        <td className="py-2 align-top text-sm text-white/60">
+                        <td className="py-2 align-top text-sm text-fg/60">
                           {desc}
                         </td>
                       </tr>
@@ -369,7 +369,7 @@ react-web3-icons/wallet`}</CodeBlock>
                   </tbody>
                 </table>
               </div>
-              <p className="mt-3 text-sm text-white/60">
+              <p className="mt-3 text-sm text-fg/60">
                 Example:{' '}
                 <code className="rounded bg-surface px-1 font-mono text-sm">
                   Ethereum
@@ -391,12 +391,12 @@ react-web3-icons/wallet`}</CodeBlock>
 
             {/* Deprecation */}
             <Section id="deprecation" title="Deprecation Policy">
-              <p className="mb-3 text-sm text-white/60">
+              <p className="mb-3 text-sm text-fg/60">
                 When a project rebrands, the old name stays as a deprecated
                 re-export alias and is removed only in a major release (after at
                 least one minor release and 90 days).
               </p>
-              <p className="mb-3 text-sm text-white/60">
+              <p className="mb-3 text-sm text-fg/60">
                 A{' '}
                 <code className="rounded bg-surface px-1 font-mono text-sm">
                   DEPRECATED_ICON_NAMES
@@ -420,7 +420,7 @@ const activeNames = Object.keys(icons).filter(
 
             {/* RSC */}
             <Section id="rsc" title="React Server Components">
-              <p className="mb-3 text-sm text-white/60">
+              <p className="mb-3 text-sm text-fg/60">
                 Icons use{' '}
                 <code className="rounded bg-surface px-1 font-mono text-sm">
                   useId
@@ -440,7 +440,7 @@ import { Ethereum } from 'react-web3-icons';
 export function MyComponent() {
   return <Ethereum size={24} />;
 }`}</CodeBlock>
-              <p className="mt-4 mb-3 text-sm text-white/60">
+              <p className="mt-4 mb-3 text-sm text-fg/60">
                 Alternatively, create a small re-export wrapper:
               </p>
               <CodeBlock>{`// icons.tsx — client boundary
@@ -450,7 +450,7 @@ export { Ethereum, Bitcoin } from 'react-web3-icons';`}</CodeBlock>
 
             {/* TypeScript */}
             <Section id="typescript" title="TypeScript">
-              <p className="mb-3 text-sm text-white/60">
+              <p className="mb-3 text-sm text-fg/60">
                 The{' '}
                 <code className="rounded bg-surface px-1 font-mono text-sm">
                   IconName
@@ -472,7 +472,7 @@ function DynamicIcon({ name, size }: { name: IconName; size?: number }) {
         {/* Sticky sidebar TOC (desktop only) */}
         <aside className="hidden lg:block">
           <nav aria-label="Table of contents" className="sticky top-8">
-            <p className="mb-3 text-xs font-medium uppercase tracking-wide text-white/50">
+            <p className="mb-3 text-xs font-medium uppercase tracking-wide text-fg/50">
               On this page
             </p>
             <ul className="flex flex-col gap-1.5 border-l border-border pl-3">
@@ -480,7 +480,7 @@ function DynamicIcon({ name, size }: { name: IconName; size?: number }) {
                 <li key={item.id}>
                   <a
                     href={`#${item.id}`}
-                    className="text-sm text-white/50 transition-colors hover:text-white/80"
+                    className="text-sm text-fg/50 transition-colors hover:text-fg/80"
                   >
                     {item.label}
                   </a>

--- a/example/src/app/layout.tsx
+++ b/example/src/app/layout.tsx
@@ -66,7 +66,7 @@ export default function RootLayout({ children }: { children: ReactNode }) {
           >
             Skip to icons
           </a>
-          <div className="flex min-h-svh flex-col theme-transition">
+          <div className="flex min-h-svh flex-col">
             <Header />
             <main className="flex-1">{children}</main>
             <Footer />

--- a/example/src/app/not-found.tsx
+++ b/example/src/app/not-found.tsx
@@ -3,11 +3,11 @@ import Link from 'next/link';
 export default function NotFound() {
   return (
     <div className="my-24 flex flex-col items-center gap-4">
-      <h1 className="text-6xl font-bold text-white/80">404</h1>
-      <p className="text-xl font-medium text-white/50">Page not found</p>
+      <h1 className="text-6xl font-bold text-fg/80">404</h1>
+      <p className="text-xl font-medium text-fg/50">Page not found</p>
       <Link
         href="/"
-        className="mt-4 rounded-lg border border-border px-5 py-2 text-sm font-medium text-white/60 transition-colors hover:bg-surface-hover hover:text-white"
+        className="mt-4 rounded-lg border border-border px-5 py-2 text-sm font-medium text-fg/60 transition-colors hover:bg-surface-hover hover:text-fg"
       >
         Back to icons
       </Link>

--- a/example/src/components/elements/CodeBlock.tsx
+++ b/example/src/components/elements/CodeBlock.tsx
@@ -19,14 +19,14 @@ export default function CodeBlock({
       className="group relative"
       {...(label ? { 'aria-label': label } : {})}
     >
-      <pre className="overflow-x-auto rounded-lg border border-border bg-surface p-4 pr-12 font-mono text-sm text-white/80">
+      <pre className="overflow-x-auto rounded-lg border border-border bg-surface p-4 pr-12 font-mono text-sm text-fg/80">
         <code>{children}</code>
       </pre>
       <button
         type="button"
         onClick={() => copy(children)}
         aria-label="Copy code"
-        className="absolute right-2 top-2 rounded p-1.5 text-white/20 opacity-0 transition-all hover:bg-white/10 hover:text-white/60 focus-visible:opacity-100 group-hover:opacity-100"
+        className="absolute right-2 top-2 rounded p-1.5 text-fg/20 opacity-0 transition-all hover:bg-fg/10 hover:text-fg/60 focus-visible:opacity-100 group-hover:opacity-100"
       >
         <CopyToggleIcon copied={copied} />
       </button>

--- a/example/src/components/sections/CategoryBar.tsx
+++ b/example/src/components/sections/CategoryBar.tsx
@@ -66,7 +66,7 @@ export default function CategoryBar() {
   return (
     <nav
       aria-label="Icon categories"
-      className="theme-transition scrollbar-none sticky top-0 z-10 overflow-x-auto border-b border-border bg-bg-nav px-4 py-2 sm:px-6"
+      className="scrollbar-none sticky top-0 z-10 overflow-x-auto border-b border-border bg-bg-nav px-4 py-2 sm:px-6"
     >
       <div ref={containerRef} className="relative flex gap-1">
         {/* Animated indicator */}

--- a/example/src/components/sections/Footer.tsx
+++ b/example/src/components/sections/Footer.tsx
@@ -2,7 +2,7 @@ import pkg from '../../../../package.json';
 
 export default function Footer() {
   return (
-    <footer className="theme-transition mt-auto border-t border-border px-4 py-4 sm:px-6">
+    <footer className="mt-auto border-t border-border px-4 py-4 sm:px-6">
       <div className="flex items-center justify-between text-xs text-fg/50">
         <div className="flex items-center gap-3">
           <span className="font-medium text-fg/60">React Web3 Icons</span>

--- a/example/src/components/sections/Header.tsx
+++ b/example/src/components/sections/Header.tsx
@@ -6,7 +6,7 @@ import GitHubButton from '../elements/GitHubButton';
 
 export default function Header() {
   return (
-    <header className="theme-transition flex items-center justify-between border-b border-border px-4 py-3 sm:px-6">
+    <header className="flex items-center justify-between border-b border-border px-4 py-3 sm:px-6">
       <div className="flex items-baseline gap-2">
         <h1 className="text-lg font-semibold tracking-tight sm:text-xl">
           <Link href="/" className="transition-opacity hover:opacity-80">

--- a/example/src/components/sections/Hero.tsx
+++ b/example/src/components/sections/Hero.tsx
@@ -30,7 +30,7 @@ export default function Hero() {
   };
 
   return (
-    <section className="theme-transition border-b border-border px-4 py-10 sm:px-6 sm:py-14">
+    <section className="border-b border-border px-4 py-10 sm:px-6 sm:py-14">
       <div className="mx-auto max-w-2xl text-center">
         <h2 className="text-2xl font-bold tracking-tight text-fg sm:text-3xl">
           {ICON_COUNT}+ Web3 icons for React

--- a/example/src/hooks/useTheme.tsx
+++ b/example/src/hooks/useTheme.tsx
@@ -46,7 +46,10 @@ export function ThemeProvider({ children }: { children: ReactNode }) {
   }, [theme]);
 
   const toggleTheme = useCallback(() => {
+    const root = document.documentElement;
+    root.classList.add('theme-changing');
     setTheme(prev => (prev === 'dark' ? 'light' : 'dark'));
+    setTimeout(() => root.classList.remove('theme-changing'), 300);
   }, []);
 
   return (

--- a/example/src/hooks/useTheme.tsx
+++ b/example/src/hooks/useTheme.tsx
@@ -6,6 +6,7 @@ import {
   useCallback,
   useContext,
   useEffect,
+  useRef,
   useState,
 } from 'react';
 
@@ -25,6 +26,7 @@ const STORAGE_KEY = 'rw3i-theme';
 
 export function ThemeProvider({ children }: { children: ReactNode }) {
   const [theme, setTheme] = useState<Theme>('dark');
+  const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   // Restore saved theme on mount
   useEffect(() => {
@@ -47,9 +49,13 @@ export function ThemeProvider({ children }: { children: ReactNode }) {
 
   const toggleTheme = useCallback(() => {
     const root = document.documentElement;
+    if (timeoutRef.current) clearTimeout(timeoutRef.current);
     root.classList.add('theme-changing');
     setTheme(prev => (prev === 'dark' ? 'light' : 'dark'));
-    setTimeout(() => root.classList.remove('theme-changing'), 300);
+    timeoutRef.current = setTimeout(() => {
+      root.classList.remove('theme-changing');
+      timeoutRef.current = null;
+    }, 300);
   }, []);
 
   return (

--- a/example/src/styles/global.css
+++ b/example/src/styles/global.css
@@ -73,11 +73,13 @@
     }
   }
 
-  .theme-transition {
+  /* Applied temporarily by ThemeProvider during toggle for synchronized transition */
+  html.theme-changing,
+  html.theme-changing * {
     transition:
       background-color 300ms ease,
       color 300ms ease,
-      border-color 300ms ease;
+      border-color 300ms ease !important;
   }
 
   input[type="range"] {

--- a/example/src/styles/global.css
+++ b/example/src/styles/global.css
@@ -79,7 +79,8 @@
     transition:
       background-color 300ms ease,
       color 300ms ease,
-      border-color 300ms ease !important;
+      border-color 300ms ease,
+      fill 300ms ease !important;
   }
 
   input[type="range"] {


### PR DESCRIPTION
## Summary

- Replace per-component `theme-transition` classes with a global `html.theme-changing *` approach that applies transitions to all elements simultaneously during theme toggle
- Update Docs, Compare, Not Found pages and CodeBlock component to use theme-aware `text-fg` tokens instead of hardcoded `text-white` classes

## Related issue

Closes #662

## Checklist

- [x] Synchronized transition on theme toggle (all elements change simultaneously)
- [x] Docs page theme-aware
- [x] Compare page theme-aware
- [x] Not Found page theme-aware
- [x] CodeBlock component theme-aware
- [x] Typecheck passes
- [x] Build passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## スタイル

* UI全体の色スキームを新しい前景色トークンシステムに統一しました。見出し、テキスト、テーブル、リンクなど全てのUI要素で一貫した色が適用されます
* テーマ遷移メカニズムを改善し、より効率的なテーマ切り替えを実現

<!-- end of auto-generated comment: release notes by coderabbit.ai -->