### PR TITLE
fix(a11y): include visible text in install button aria-label

### DIFF
--- a/example/src/components/sections/Hero.tsx
+++ b/example/src/components/sections/Hero.tsx
@@ -58,7 +58,7 @@ export default function Hero() {
           <button
             type="button"
             onClick={() => copy(INSTALL_CMDS[pkg])}
-            aria-label="Copy install command"
+            aria-label={`Copy ${INSTALL_CMDS[pkg]}`}
             className="flex items-center gap-3 rounded-lg border border-border bg-surface px-5 py-2.5 font-mono text-sm text-fg/80 transition-colors hover:bg-surface-hover"
           >
             <span className="select-all">{INSTALL_CMDS[pkg]}</span>


### PR DESCRIPTION
## Summary

- Make the Hero install button's `aria-label` dynamic to include the displayed command text (e.g., `Copy npm i react-web3-icons`), satisfying WCAG 2.5.3 (Label in Name)

## Related issue

Closes #673

## Checklist

- [x] `aria-label` includes visible button text
- [x] Lint and typecheck pass
- [x] No changeset needed (example-only change)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## アクセシビリティの改善

* **アクセシビリティ**
  * インストールコマンドのコピーボタンの説明文が、選択されているパッケージマネージャーの実際のコマンドを含めるように更新されました。ユーザーがコピーされるコマンドをより明確に認識できるようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->