### PR TITLE
feat(devtool): add Viem icon variants

### DIFF
--- a/.changeset/add-viem-icon.md
+++ b/.changeset/add-viem-icon.md
@@ -1,0 +1,5 @@
+---
+"react-web3-icons": minor
+---
+
+Add Viem icon variants (Viem, ViemMono) to devtool category

--- a/src/devtool/Viem.tsx
+++ b/src/devtool/Viem.tsx
@@ -1,0 +1,18 @@
+import { createIcon } from '../utils';
+
+// Source: https://github.com/wevm/viem/blob/main/site/public/logo-light-hug.svg
+
+const viemContent = () => (
+  <path d="m83.3 220.4 52.36-123.42c7.14-17.34 9.86-19.04 24.48-19.04V70.8H107.1v7.14c13.6 0 20.06.68 20.06 7.82 0 2.72-.68 6.12-2.72 11.22l-30.26 75.48-32.64-76.5c-1.7-4.76-2.72-8.16-2.72-10.54 0-6.8 6.46-7.48 18.02-7.48V70.8H1.02v7.14c13.94 0 15.98 2.72 22.78 17.68L81.26 220.4z" />
+);
+
+/** Viem dev tool icon (colored). */
+export const Viem = createIcon('Viem', '0 70 162 152', viemContent, '#1E1E20');
+
+/** Viem dev tool icon (monochrome). */
+export const ViemMono = createIcon(
+  'ViemMono',
+  '0 70 162 152',
+  viemContent,
+  'currentColor',
+);

--- a/src/devtool/index.ts
+++ b/src/devtool/index.ts
@@ -15,5 +15,6 @@ export * from './Tenderly';
 export * from './TheGraph';
 export * from './Thirdweb';
 export * from './Truffle';
+export * from './Viem';
 export * from './Wagmi';
 export * from './Web3Js';


### PR DESCRIPTION
## Summary

- Add `Viem` (colored, `#1E1E20`) and `ViemMono` (monochrome) icon components to the devtool category
- Path data extracted from the official wordmark SVG in the [wevm/viem](https://github.com/wevm/viem) repository (`site/public/logo-light-hug.svg`)
- SVGO-optimized to 368 bytes

## Related issue

Closes #314

## Checklist

- [x] Source from official repository (wordmark SVG)
- [x] `// Source:` attribution comment included
- [x] SVGO optimization applied
- [x] Colored and mono variants created
- [x] Exported from `src/devtool/index.ts`
- [x] Visual verification against official PNG
- [x] All checks pass (lint, typecheck, test, build, size)
- [x] Changeset added