### PR TITLE
chore: add pnpm minimum-release-age to reduce supply-chain risk

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,2 @@
 engine-strict=true
+minimum-release-age=4320


### PR DESCRIPTION
## Summary
- Set pnpm's `minimum-release-age` to 3 days (4320 minutes) in `.npmrc`.
- `pnpm install` will now refuse to resolve to a package version published less than 3 days ago, falling back to the next-newest eligible version instead — this gives the ecosystem time to catch and flag compromised releases (a common supply-chain attack pattern: publish a malicious version, get it installed broadly within hours, before anyone notices).

## Related issue
Closes #690

## Checklist
- [x] `pnpm install` resolves successfully with the current lockfile
- [x] No breaking changes; config-only
- [x] No changeset needed (no `src/` change)