### PR TITLE
fix: remove broken require condition from ./deprecated exports; add publint + attw to CI

### DIFF
--- a/.changeset/fix-deprecated-exports.md
+++ b/.changeset/fix-deprecated-exports.md
@@ -1,0 +1,5 @@
+---
+'react-web3-icons': patch
+---
+
+Fix the `./deprecated` subpath export: its `require` condition pointed to `dist/deprecated.cjs` / `dist/deprecated.d.cts`, which are never produced by the ESM-only build, so `require('react-web3-icons/deprecated')` failed with a missing-file error. The subpath now declares only the ESM entry, consistent with every other subpath.

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -89,3 +89,32 @@ jobs:
 
       - name: Build example app
         run: pnpm --filter react-web3-icons-example run build
+
+  package-checks:
+    name: Package validation (publint, attw)
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v6
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Use Node 24.x
+        uses: actions/setup-node@v6
+        with:
+          node-version: '24.x'
+          cache: pnpm
+
+      - name: Install deps
+        run: pnpm install --frozen-lockfile
+
+      - name: Build library
+        run: pnpm run build
+
+      - name: publint
+        run: pnpm dlx publint --strict
+
+      - name: Are the types wrong
+        run: pnpm dlx @arethetypeswrong/cli --pack . --profile esm-only

--- a/package.json
+++ b/package.json
@@ -43,14 +43,8 @@
       "default": "./dist/bridge/index.mjs"
     },
     "./deprecated": {
-      "import": {
-        "types": "./dist/deprecated.d.mts",
-        "default": "./dist/deprecated.mjs"
-      },
-      "require": {
-        "types": "./dist/deprecated.d.cts",
-        "default": "./dist/deprecated.cjs"
-      }
+      "types": "./dist/deprecated.d.mts",
+      "default": "./dist/deprecated.mjs"
     },
     "./chain": {
       "types": "./dist/chain/index.d.mts",


### PR DESCRIPTION
## Summary

- Fix the `./deprecated` subpath export: its `require` condition pointed to `dist/deprecated.cjs` / `dist/deprecated.d.cts`, which the ESM-only build (`format: ['esm']` in tsdown.config.ts) never produces — `require('react-web3-icons/deprecated')` failed with a missing-file error in every release since the ESM-only migration. The subpath now declares only the ESM entry, consistent with every other subpath.
- Add a `package-checks` CI job that builds and then runs `publint --strict` and `@arethetypeswrong/cli --pack . --profile esm-only` against the packed tarball, so exports-map drift of this kind fails CI instead of shipping. Both tools verified green locally after the fix (publint reported the two missing-file errors before it).

## Related issue

Closes #714

## Icon source verification (required for icon add/update PRs)

N/A

## Breaking changes / Deprecations

N/A — the removed `require` condition never worked (the files it pointed to did not exist), so no functioning consumer path changes.

## Checklist

- [x] Lint passes (`pnpm run check`)
- [x] Tests pass (`pnpm test`) — 5016 passed
- [x] Build succeeds (`pnpm run build`)
- [x] Changeset included (if `src/` changed): patch changeset included (package.json exports fix affects the published package)
- [x] Official icon source and usage context documented above (or N/A)
- [x] Default icon geometry/colors match official asset (or N/A)
- [x] Compare page updated if library features changed (N/A)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FaQCzvxapyUZ3vgJurLa7H

---
_Generated by [Claude Code](https://claude.ai/code/session_01FaQCzvxapyUZ3vgJurLa7H)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **バグ修正**
  * `react-web3-icons/deprecated` のエクスポート設定を修正し、ESM環境で正しく読み込めるようになりました。

* **品質改善**
  * パッケージの公開設定と型情報を自動検証するチェックを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->