### PR TITLE
feat: expose raw SVG files via ./svg/* subpath export

### DIFF
--- a/.changeset/add-svg-subpath-export.md
+++ b/.changeset/add-svg-subpath-export.md
@@ -1,0 +1,5 @@
+---
+'react-web3-icons': minor
+---
+
+Expose the generated raw SVG files through a `./svg/*` subpath export (`react-web3-icons/svg/<category>/<Name>.svg`). The files were already shipped in the package but were unreachable because the `exports` map blocked the subpath. Also documents bundler and CDN (jsdelivr/unpkg) usage in the README.

--- a/README.md
+++ b/README.md
@@ -129,6 +129,28 @@ The root import still works and includes all icons:
 import { Ethereum } from 'react-web3-icons';
 ```
 
+### Raw SVG Files
+
+Every icon is also published as a plain, optimized SVG file under the `svg/` subpath — useful outside React (Vue, Svelte, static HTML, image pipelines, design tools):
+
+```
+react-web3-icons/svg/<category>/<Name>.svg
+```
+
+```ts
+// With a bundler (Vite, webpack, Next.js) — resolves to a URL or asset per your config
+import ethereumSvgUrl from 'react-web3-icons/svg/chain/Ethereum.svg';
+```
+
+The files have no fixed `width`/`height`, so they scale to their container. Mono variants use `currentColor` and inherit CSS `color`.
+
+You can also hotlink them from a CDN without installing the package:
+
+```
+https://cdn.jsdelivr.net/npm/react-web3-icons@latest/dist/svg/chain/Ethereum.svg
+https://unpkg.com/react-web3-icons@latest/dist/svg/chain/Ethereum.svg
+```
+
 ### IconContext
 
 Use `IconContext.Provider` to set default props for all icons in a subtree:

--- a/package.json
+++ b/package.json
@@ -114,7 +114,8 @@
     "./dynamic": {
       "types": "./dist/dynamic/index.d.mts",
       "default": "./dist/dynamic/index.mjs"
-    }
+    },
+    "./svg/*": "./dist/svg/*"
   },
   "sideEffects": false,
   "files": [

--- a/test/subpath-exports.test.ts
+++ b/test/subpath-exports.test.ts
@@ -129,3 +129,14 @@ describe('Category module exports', () => {
     expect(Object.keys(wallet)).toContain('CoinbaseWalletMono');
   });
 });
+
+describe('package.json exports map', () => {
+  it('exposes raw SVG files via the ./svg/* wildcard subpath', async () => {
+    const { readFileSync } = await import('node:fs');
+    const { join } = await import('node:path');
+    const pkg = JSON.parse(
+      readFileSync(join(import.meta.dirname, '../package.json'), 'utf-8'),
+    ) as { exports: Record<string, unknown> };
+    expect(pkg.exports['./svg/*']).toBe('./dist/svg/*');
+  });
+});


### PR DESCRIPTION
## Summary

- Add `"./svg/*": "./dist/svg/*"` to the `exports` map. The 660+ generated SVGs (from #653) were already shipped in the tarball but unreachable — the `exports` field blocks unlisted subpaths, so `import 'react-web3-icons/svg/...'` failed in every bundler. Verified after the change: `require.resolve('react-web3-icons/svg/chain/Ethereum.svg')` resolves, and `publint --strict` stays green.
- README: new "Raw SVG Files" section documenting the subpath, sizing/`currentColor` behavior, and zero-install CDN access via jsdelivr/unpkg.
- Test: guards the `./svg/*` entry in the exports map.

## Related issue

Closes #699

## Icon source verification (required for icon add/update PRs)

N/A

## Breaking changes / Deprecations

N/A — additive.

## Checklist

- [x] Lint passes (`pnpm run check`)
- [x] Tests pass (`pnpm test`) — 5222 passed
- [x] Build succeeds (`pnpm run build`)
- [x] Changeset included (if `src/` changed): minor changeset included (new public subpath)
- [x] Official icon source and usage context documented above (or N/A)
- [x] Default icon geometry/colors match official asset (or N/A)
- [x] Compare page updated if library features changed (N/A — can be added to the compare page in a follow-up)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FaQCzvxapyUZ3vgJurLa7H

---
_Generated by [Claude Code](https://claude.ai/code/session_01FaQCzvxapyUZ3vgJurLa7H)_