### PR TITLE
ci: replace retired pnpm audit with dependency review; cache Playwright browsers

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,18 +13,20 @@ concurrency:
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
-  audit:
-    name: Security audit
+  # Replaces the former `pnpm audit` job: the npm registry retired the audit
+  # endpoints it relied on (HTTP 410, see #695). Dependency review checks the
+  # dependency diff of each PR against the GitHub Advisory Database; existing
+  # dependencies are covered by Dependabot alerts, weekly CodeQL, and pnpm's
+  # minimumReleaseAge.
+  dependency-review:
+    name: Dependency review
+    if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: pnpm/action-setup@v4
-      - uses: actions/setup-node@v6
+      - uses: actions/dependency-review-action@v4
         with:
-          node-version: '24.x'
-          cache: pnpm
-      - run: pnpm install --frozen-lockfile
-      - run: pnpm audit --audit-level=high
+          fail-on-severity: high
 
   build:
     name: Build, lint, and test on Node ${{ matrix.node }}

--- a/.github/workflows/visual-regression.yml
+++ b/.github/workflows/visual-regression.yml
@@ -38,8 +38,24 @@ jobs:
 
       - run: pnpm install --frozen-lockfile
 
+      - name: Get Playwright version
+        id: playwright-version
+        run: echo "version=$(pnpm ls playwright --depth=0 --parseable --long | grep -oP 'playwright@\K[0-9.]+' | head -1)" >> $GITHUB_OUTPUT
+
+      - name: Cache Playwright browsers
+        id: playwright-cache
+        uses: actions/cache@v5
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-${{ steps.playwright-version.outputs.version }}
+
       - name: Install Playwright browsers
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
         run: pnpm exec playwright install --with-deps chromium
+
+      - name: Install Playwright system dependencies only (cache hit)
+        if: steps.playwright-cache.outputs.cache-hit == 'true'
+        run: pnpm exec playwright install-deps chromium
 
       # On develop: generate and cache reference screenshots
       - name: Restore reference screenshots (develop)


### PR DESCRIPTION
## Summary

- **Fix the permanently red Security audit job (#695).** The npm registry retired both audit endpoints `pnpm audit` relied on (HTTP 410), so the job could never pass again. Replaced with `actions/dependency-review-action` (`fail-on-severity: high`), which checks each PR's dependency diff against the GitHub Advisory Database — GitHub-native, no retired endpoints, and it can't go red from infrastructure decay. Coverage for *existing* dependencies remains layered: Dependabot alerts, weekly CodeQL, and pnpm `minimumReleaseAge`. Rationale documented in a workflow comment.
- **Cache Playwright browsers in the visual-regression workflow** (#716, first half): keyed on the installed Playwright version from the lockfile; on cache hit only `playwright install-deps chromium` runs (system libraries aren't cacheable). Saves the ~100 MB browser download on every `src/**` push/PR. The version-extraction command was verified locally (resolves `1.61.1` from the current lockfile). Both files pass YAML validation.

The size-limit-action replacement (second half of #716) is intentionally left for a follow-up — it needs validation on a live PR.

## Related issue

Closes #695. Part of #716.

## Icon source verification (required for icon add/update PRs)

N/A

## Breaking changes / Deprecations

N/A

## Checklist

- [x] Lint passes (`pnpm run check`)
- [x] Tests pass (`pnpm test`)
- [x] Build succeeds (`pnpm run build`)
- [x] Changeset included (if `src/` changed): N/A — CI-only changes
- [x] Official icon source and usage context documented above (or N/A)
- [x] Default icon geometry/colors match official asset (or N/A)
- [x] Compare page updated if library features changed (N/A)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FaQCzvxapyUZ3vgJurLa7H

---
_Generated by [Claude Code](https://claude.ai/code/session_01FaQCzvxapyUZ3vgJurLa7H)_