### PR TITLE
docs: add trademark disclaimer to README and demo footer

### DIFF
--- a/README.md
+++ b/README.md
@@ -376,6 +376,19 @@ import { DEPRECATED_ICON_NAMES } from 'react-web3-icons/deprecated';
 
 Full process and test requirements: [CONTRIBUTING.md#icon-lifecycle-policy](CONTRIBUTING.md#icon-lifecycle-policy).
 
+## Trademarks
+
+All product names, logos, and brands contained in this library are the property
+of their respective owners and are used for identification purposes only. Their
+inclusion does not imply any affiliation with or endorsement by the trademark
+holders. The MIT license covers this library's code, not the trademarks
+themselves — your use of a logo remains subject to the brand guidelines of its
+owner.
+
+If you are a rights holder and would like an icon corrected or removed, please
+[open an issue](https://github.com/derodero24/react-web3-icons/issues/new/choose)
+and we will address it promptly.
+
 ## License
 
 [MIT](LICENSE)

--- a/example/src/components/sections/Footer.tsx
+++ b/example/src/components/sections/Footer.tsx
@@ -8,6 +8,9 @@ export default function Footer() {
           <span className="font-medium text-fg/60">React Web3 Icons</span>
           <span className="font-mono">v{pkg.version}</span>
           <span>MIT</span>
+          <span className="hidden sm:inline">
+            All logos are trademarks of their respective owners.
+          </span>
         </div>
         <div className="flex items-center gap-4">
           <a


### PR DESCRIPTION
## Summary

- README: new "Trademarks" section (placed above License) clarifying that all product names, logos, and brands are property of their respective owners, that MIT covers the code but not the marks, and that rights holders can request corrections/removal via the issue tracker — the standard posture for brand-icon libraries (cf. simple-icons)
- Demo site footer: one-line "All logos are trademarks of their respective owners." notice (hidden on small screens to avoid crowding)

## Related issue

Closes #713

## Icon source verification (required for icon add/update PRs)

N/A

## Breaking changes / Deprecations

N/A

## Checklist

- [x] Lint passes (`pnpm run check`)
- [x] Tests pass (`pnpm test`)
- [x] Build succeeds (`pnpm run build`)
- [x] Changeset included (if `src/` changed): N/A — docs/example only
- [x] Official icon source and usage context documented above (or N/A)
- [x] Default icon geometry/colors match official asset (or N/A)
- [x] Compare page updated if library features changed (N/A)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FaQCzvxapyUZ3vgJurLa7H

---
_Generated by [Claude Code](https://claude.ai/code/session_01FaQCzvxapyUZ3vgJurLa7H)_