### PR TITLE
chore(renovate): block TypeScript 7 major until rolldown-plugin-dts supports it

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -74,6 +74,16 @@
         "package.json"
       ],
       "automerge": false
+    },
+    {
+      "description": "Block TypeScript 7 until rolldown-plugin-dts supports it (see issue #717)",
+      "matchPackageNames": [
+        "typescript"
+      ],
+      "matchUpdateTypes": [
+        "major"
+      ],
+      "enabled": false
     }
   ]
 }


### PR DESCRIPTION
## Summary

Evaluation result for #717, tested on this tree with `typescript@7.0.2`:

| Check | Result |
| --- | --- |
| `tsc --noEmit` (src + tests, `@tsconfig/strictest`) | ✅ passes, ~1.9 s wall time |
| `pnpm test` | ✅ 5222 passed |
| `pnpm run build` (tsdown `dts: true`) | ❌ **fails** — `rolldown-plugin-dts@0.22.5` crashes under TS 7: `TypeError: Cannot read properties of undefined (reading 'useCaseSensitiveFileNames')` in its `tsc-*` module; `dist/*.d.mts` is never emitted (publint then reports 44 missing-file errors) |

The type-declaration output is a hard requirement, so the upgrade is blocked upstream. This PR records the decision as config: a Renovate `packageRules` entry disables the `typescript` major update (with a pointer to #717) so the dashboard/major PR doesn't sit permanently open. Revisit when rolldown-plugin-dts (via a tsdown upgrade — likely after #693 unlocks tsdown 0.22+) supports TS 7 — the typecheck-side win is real.

## Related issue

Closes #717 (decision recorded: blocked-with-reason + Renovate rule, per the issue's completion criteria)

## Icon source verification (required for icon add/update PRs)

N/A

## Breaking changes / Deprecations

N/A

## Checklist

- [x] Lint passes (`pnpm run check`)
- [x] Tests pass (`pnpm test`)
- [x] Build succeeds (`pnpm run build`) — verified back on TS 5.9.3 after the evaluation
- [x] Changeset included (if `src/` changed): N/A
- [x] Official icon source and usage context documented above (or N/A)
- [x] Default icon geometry/colors match official asset (or N/A)
- [x] Compare page updated if library features changed (N/A)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FaQCzvxapyUZ3vgJurLa7H

---
_Generated by [Claude Code](https://claude.ai/code/session_01FaQCzvxapyUZ3vgJurLa7H)_