### PR TITLE
ci: replace unmaintained size-limit-action with size-limit + sticky PR comment

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -14,6 +14,6 @@ jobs:
       contents: read
       pull-requests: write
     steps:
-      - uses: actions/labeler@634933edcd8ababfe52f92936142cc22ac488b1b # v6
+      - uses: actions/labeler@634933edcd8ababfe52f92936142cc22ac488b1b # v6.0.1
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/size.yml
+++ b/.github/workflows/size.yml
@@ -12,15 +12,76 @@ concurrency:
 jobs:
   size:
     runs-on: ubuntu-latest
-    env:
-      CI_JOB_NUMBER: 1
     steps:
       - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+          fetch-depth: 0
+
       - uses: pnpm/action-setup@v4
+
       - uses: actions/setup-node@v6
         with:
           node-version: '24.x'
           cache: pnpm
-      - uses: andresz1/size-limit-action@94bc357df29c36c8f8d50ea497c3e225c3c95d1d # v1.8.0
+
+      - name: Measure PR bundle sizes
+        run: |
+          pnpm install --frozen-lockfile
+          pnpm exec tsdown
+          pnpm exec size-limit --json > /tmp/size-pr.json
+
+      - name: Measure base branch bundle sizes
+        # Best-effort: if the base branch fails to build or measure, the
+        # report degrades to PR-only sizes instead of failing the job.
+        run: |
+          git worktree add /tmp/base-checkout ${{ github.event.pull_request.base.sha }}
+          cd /tmp/base-checkout
+          if pnpm install --frozen-lockfile && pnpm exec tsdown && pnpm exec size-limit --json > /tmp/size-base.json; then
+            echo "Base branch measured."
+          else
+            echo "::warning::Could not measure base branch; reporting PR sizes only."
+            rm -f /tmp/size-base.json
+          fi
+
+      - name: Render size report (fails when limits are exceeded)
+        run: |
+          if [ -f /tmp/size-base.json ]; then
+            node scripts/size-report.mjs /tmp/size-pr.json /tmp/size-base.json > /tmp/size-report.md
+          else
+            node scripts/size-report.mjs /tmp/size-pr.json > /tmp/size-report.md
+          fi
+
+      - name: Comment size report on PR
+        if: always()
+        uses: actions/github-script@v8
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const { readFileSync, existsSync } = require('node:fs');
+            if (!existsSync('/tmp/size-report.md')) {
+              return;
+            }
+            const body = readFileSync('/tmp/size-report.md', 'utf-8');
+            const marker = '<!-- size-report -->';
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              per_page: 100,
+            });
+            const existing = comments.find(c => c.body?.includes(marker));
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+                body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                body,
+              });
+            }

--- a/scripts/size-report.mjs
+++ b/scripts/size-report.mjs
@@ -1,0 +1,79 @@
+#!/usr/bin/env node
+/**
+ * Renders a markdown report from `size-limit --json` output, optionally
+ * comparing against a base-branch run.
+ *
+ * Usage:
+ *   size-limit --json > pr.json
+ *   node scripts/size-report.mjs pr.json [base.json] > report.md
+ *
+ * Exits 1 if any entry exceeds its limit, so CI fails with the report
+ * still written to stdout.
+ */
+
+import { readFileSync } from 'node:fs';
+
+const [prPath, basePath] = process.argv.slice(2);
+if (!prPath) {
+  console.error('Usage: node scripts/size-report.mjs <pr.json> [base.json]');
+  process.exit(2);
+}
+
+/** @typedef {{ name: string, passed: boolean, size: number, sizeLimit?: number }} Entry */
+
+/** @returns {Entry[]} */
+function load(path) {
+  return JSON.parse(readFileSync(path, 'utf-8'));
+}
+
+function formatBytes(bytes) {
+  if (bytes >= 1024) {
+    return `${(bytes / 1024).toFixed(2)} KB`;
+  }
+  return `${bytes} B`;
+}
+
+function formatDelta(delta) {
+  if (delta === 0) {
+    return '=';
+  }
+  const sign = delta > 0 ? '+' : '';
+  return `${sign}${formatBytes(Math.abs(delta)).replace(/^/, delta < 0 ? '-' : '')}`;
+}
+
+const pr = load(prPath);
+const base = basePath ? new Map(load(basePath).map(e => [e.name, e])) : null;
+
+const rows = pr.map(entry => {
+  const limit = entry.sizeLimit ? formatBytes(entry.sizeLimit) : '—';
+  const status = entry.passed ? '✅' : '❌';
+  const baseEntry = base?.get(entry.name);
+  const delta =
+    baseEntry === undefined ? 'new' : formatDelta(entry.size - baseEntry.size);
+  return `| ${entry.name} | ${formatBytes(entry.size)} | ${delta} | ${limit} | ${status} |`;
+});
+
+const changed = pr.filter(e => {
+  const b = base?.get(e.name);
+  return !e.passed || b === undefined || b.size !== e.size;
+});
+
+const lines = [
+  '<!-- size-report -->',
+  '## 📦 Bundle size',
+  '',
+  base && changed.length === 0
+    ? '_No size changes against the base branch._'
+    : '',
+  '| Entry | Size (min+brotli) | Δ vs base | Limit | |',
+  '| --- | --- | --- | --- | --- |',
+  ...rows,
+  '',
+];
+
+console.log(lines.filter(l => l !== '').join('\n'));
+
+if (pr.some(e => !e.passed)) {
+  console.error('size-limit: one or more entries exceed their limit');
+  process.exit(1);
+}


### PR DESCRIPTION
## Summary

Completes #716. `andresz1/size-limit-action@1.8.0` (2022 build, effectively unmaintained, runs its own install logic) was the last stale third-party runner in CI. Replaced with first-party pieces:

- **Enforcement**: `size-limit --json` runs on the PR checkout; `scripts/size-report.mjs` exits 1 when any entry exceeds its limit (verified locally: exit 0 on green, exit 1 when an entry fails)
- **Base comparison**: the base commit is built in a `git worktree` and measured with *its own* size-limit config; per-entry Δ is shown in the report. If the base can't be built/measured, the job degrades to PR-only sizes with a warning instead of failing
- **Sticky comment**: `actions/github-script` updates a single marker-tagged comment per PR (same pattern as `changeset-check.yml`)

The report renderer was tested locally against real `size-limit --json` output (delta formatting, "new entry" handling, failure exit codes). Workflow passes YAML validation and zizmor. This PR's own Size check runs the new workflow end-to-end.

## Related issue

Closes #716 (the Playwright-cache half landed in #726)

## Icon source verification (required for icon add/update PRs)

N/A

## Breaking changes / Deprecations

N/A

## Checklist

- [x] Lint passes (`pnpm run check`)
- [x] Tests pass (`pnpm test`)
- [x] Build succeeds (`pnpm run build`)
- [x] Changeset included (if `src/` changed): N/A — CI/scripts only
- [x] Official icon source and usage context documented above (or N/A)
- [x] Default icon geometry/colors match official asset (or N/A)
- [x] Compare page updated if library features changed (N/A)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FaQCzvxapyUZ3vgJurLa7H

---
_Generated by [Claude Code](https://claude.ai/code/session_01FaQCzvxapyUZ3vgJurLa7H)_