### PR TITLE
feat: ship IconifyJSON collections generated from the icon source tree

### DIFF
--- a/.changeset/iconify-collections.md
+++ b/.changeset/iconify-collections.md
@@ -1,0 +1,5 @@
+---
+'react-web3-icons': minor
+---
+
+Ship IconifyJSON collections: `react-web3-icons/iconify.json` (colored, prefix `web3`) and `react-web3-icons/iconify-mono.json` (`currentColor`, prefix `web3-mono`), generated from the icon source tree and validated with `@iconify/utils`. This makes the full set usable from Vue, Svelte, Web Components, `unplugin-icons`, and the rest of the Iconify ecosystem; ticker and deprecated re-exports are registered as Iconify aliases.

--- a/README.md
+++ b/README.md
@@ -152,6 +152,20 @@ https://cdn.jsdelivr.net/npm/react-web3-icons@latest/dist/svg/chain/Ethereum.svg
 https://unpkg.com/react-web3-icons@latest/dist/svg/chain/Ethereum.svg
 ```
 
+### Iconify (Vue, Svelte, Tailwind, and more)
+
+The full set also ships as IconifyJSON collections — `react-web3-icons/iconify.json` (colored, prefix `web3`) and `react-web3-icons/iconify-mono.json` (`currentColor`, prefix `web3-mono`) — so the icons work outside React through the Iconify ecosystem:
+
+```tsx
+import { addCollection, Icon } from '@iconify/react';
+import web3Icons from 'react-web3-icons/iconify.json';
+
+addCollection(web3Icons);
+<Icon icon="web3:chain-ethereum" />;
+```
+
+Icon names are `<category>-<kebab-name>` (e.g. `chain-ethereum`, `coin-bitcoin`, `wallet-meta-mask`); ticker shorthands are registered as Iconify aliases (e.g. `coin-btc`). The same JSON works with Iconify's Vue/Svelte/Web Component packages and `unplugin-icons`.
+
 ### React Server Components (RSC)
 
 Static icons are pure, hook-free components. They render in React Server Components with no `'use client'` directive:

--- a/package.json
+++ b/package.json
@@ -122,6 +122,8 @@
       "default": "./dist/manifest/index.mjs"
     },
     "./manifest.json": "./dist/manifest.json",
+    "./iconify.json": "./dist/iconify.json",
+    "./iconify-mono.json": "./dist/iconify-mono.json",
     "./svg/*": "./dist/svg/*"
   },
   "sideEffects": false,
@@ -130,7 +132,7 @@
   ],
   "scripts": {
     "analyze": "size-limit --why",
-    "build": "tsdown && node scripts/build-icons/emit-dist-svg.mjs && node scripts/generate-manifest.mjs --json",
+    "build": "tsdown && node scripts/build-icons/emit-dist-svg.mjs && node scripts/build-icons/emit-iconify.mjs && node scripts/generate-manifest.mjs --json",
     "new-icon": "node scripts/new-icon.mjs",
     "check": "biome ci",
     "format": "biome format --write",
@@ -154,6 +156,7 @@
     "@changesets/cli": "^2.29.8",
     "@commitlint/cli": "^20.4.4",
     "@commitlint/config-conventional": "^20.4.4",
+    "@iconify/utils": "^3.1.4",
     "@size-limit/preset-small-lib": "^12.0.0",
     "@tsconfig/strictest": "^2.0.8",
     "@types/node": "^25.3.5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -31,6 +31,9 @@ importers:
       '@commitlint/config-conventional':
         specifier: ^20.4.4
         version: 20.5.3
+      '@iconify/utils':
+        specifier: ^3.1.4
+        version: 3.1.4
       '@size-limit/preset-small-lib':
         specifier: ^12.0.0
         version: 12.1.0(size-limit@12.1.0(jiti@2.7.0))
@@ -143,6 +146,9 @@ packages:
   '@alloc/quick-lru@5.2.0':
     resolution: {integrity: sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==}
     engines: {node: '>=10'}
+
+  '@antfu/install-pkg@1.1.0':
+    resolution: {integrity: sha512-MGQsmw10ZyI+EJo45CdSER4zEb+p31LpDAFp2Z3gkSd1yqVZGi0Ebx++YTEMonJy4oChEMLsxZ64j8FH6sSqtQ==}
 
   '@asamuzakjp/css-color@5.1.11':
     resolution: {integrity: sha512-KVw6qIiCTUQhByfTd78h2yD1/00waTmm9uy/R7Ck/ctUyAPj+AEDLkQIdJW0T8+qGgj3j5bpNKK7Q3G+LedJWg==}
@@ -619,6 +625,12 @@ packages:
     peerDependenciesMeta:
       '@noble/hashes':
         optional: true
+
+  '@iconify/types@2.0.0':
+    resolution: {integrity: sha512-+wluvCrRhXrhyOmRDJ3q8mux9JkKy5SJ/v8ol2tu4FVjyYvtEzkc/3pK15ET6RKg4b4w4BmTk1+gsCUhf21Ykg==}
+
+  '@iconify/utils@3.1.4':
+    resolution: {integrity: sha512-b1S7B1k9ohZ+iNTi2ATxbRYG9fTrJmUT0rc46bvVnNxqNRGW7dyo/vRREwyniI5IRN2RSJHDcm+s3BjWrSAjHw==}
 
   '@img/colour@1.1.0':
     resolution: {integrity: sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==}
@@ -2175,6 +2187,9 @@ packages:
   package-manager-detector@0.2.11:
     resolution: {integrity: sha512-BEnLolu+yuz22S56CU1SUKq3XC3PkwD5wv4ikR4MfGvnRVcmzXR9DwSlW2fEamyTPyXHomBJRzgapeuBvRNzJQ==}
 
+  package-manager-detector@1.7.0:
+    resolution: {integrity: sha512-xg1eHpwYL/D/HEdWw2goFZP6vV0FH7W+PZ5rFkGjdIDLtxq7EkzBUeT3m+lndYCt8wKbmofUu1MUdMCXkCk9ZQ==}
+
   parent-module@1.0.1:
     resolution: {integrity: sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==}
     engines: {node: '>=6'}
@@ -2232,6 +2247,10 @@ packages:
 
   postcss@8.4.31:
     resolution: {integrity: sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==}
+    engines: {node: ^10 || ^12 || >=14}
+
+  postcss@8.5.18:
+    resolution: {integrity: sha512-xdB1oSLHbz1vRWgCDalrCqEFTWzFlhqFC5tIHLMOSUIjhm3XXQ1qrFy8S/ESr1JYRRXqM3c1QFiMZUJdUTqyMQ==}
     engines: {node: ^10 || ^12 || >=14}
 
   postcss@8.5.19:
@@ -2722,6 +2741,11 @@ packages:
 snapshots:
 
   '@alloc/quick-lru@5.2.0': {}
+
+  '@antfu/install-pkg@1.1.0':
+    dependencies:
+      package-manager-detector: 1.7.0
+      tinyexec: 1.2.4
 
   '@asamuzakjp/css-color@5.1.11':
     dependencies:
@@ -3232,6 +3256,14 @@ snapshots:
     optional: true
 
   '@exodus/bytes@1.15.1': {}
+
+  '@iconify/types@2.0.0': {}
+
+  '@iconify/utils@3.1.4':
+    dependencies:
+      '@antfu/install-pkg': 1.1.0
+      '@iconify/types': 2.0.0
+      import-meta-resolve: 4.2.0
 
   '@img/colour@1.1.0':
     optional: true
@@ -4499,6 +4531,8 @@ snapshots:
     dependencies:
       quansync: 0.2.11
 
+  package-manager-detector@1.7.0: {}
+
   parent-module@1.0.1:
     dependencies:
       callsites: 3.1.0
@@ -4541,6 +4575,12 @@ snapshots:
   pngjs@7.0.0: {}
 
   postcss@8.4.31:
+    dependencies:
+      nanoid: 3.3.16
+      picocolors: 1.1.1
+      source-map-js: 1.2.1
+
+  postcss@8.5.18:
     dependencies:
       nanoid: 3.3.16
       picocolors: 1.1.1
@@ -4886,7 +4926,7 @@ snapshots:
     dependencies:
       lightningcss: 1.32.0
       picomatch: 4.0.5
-      postcss: 8.5.19
+      postcss: 8.5.18
       rolldown: 1.1.5
       tinyglobby: 0.2.17
     optionalDependencies:

--- a/scripts/build-icons/emit-iconify.mjs
+++ b/scripts/build-icons/emit-iconify.mjs
@@ -1,0 +1,249 @@
+#!/usr/bin/env node
+/**
+ * Emits IconifyJSON collections from the icons/ source tree:
+ *
+ *   dist/iconify.json       — colored icons  (prefix: web3)
+ *   dist/iconify-mono.json  — currentColor icons (prefix: web3-mono)
+ *
+ * Icon names are `<category>-<kebab-name>` (e.g. `chain-ethereum-circle`);
+ * ticker/deprecated re-exports become Iconify aliases (deprecated ones
+ * hidden). Internal SVG ids are prefixed per icon so inlined icons never
+ * collide on a page.
+ */
+
+import { writeFileSync } from 'node:fs';
+import { join, resolve } from 'node:path';
+import { CATEGORIES, loadCategory } from './lib.mjs';
+import { parseSvg, serializeSvg } from './xml.mjs';
+
+const ROOT = resolve(import.meta.dirname, '../..');
+const ICONS = join(ROOT, 'icons');
+
+const kebab = name =>
+  name
+    .replace(/([a-z0-9])([A-Z])/g, '$1-$2')
+    .replace(/([A-Z])([A-Z][a-z])/g, '$1-$2')
+    .toLowerCase();
+
+/** Prefixes internal ids with the icon name to avoid cross-icon collisions. */
+function namespaceIds(node, prefix, ids) {
+  node.attrs = node.attrs.map(([name, value]) => {
+    if (name === 'id' && ids.has(value)) {
+      return [name, `${prefix}-${value}`];
+    }
+    if ((name === 'href' || name === 'xlink:href') && value.startsWith('#')) {
+      const target = value.slice(1);
+      if (ids.has(target)) {
+        return [name, `#${prefix}-${target}`];
+      }
+    }
+    if (value.includes('url(#')) {
+      return [
+        name,
+        value.replace(/url\(#([^)]+)\)/g, (whole, id) =>
+          ids.has(id) ? `url(#${prefix}-${id})` : whole,
+        ),
+      ];
+    }
+    return [name, value];
+  });
+  for (const child of node.children) {
+    namespaceIds(child, prefix, ids);
+  }
+}
+
+function collectIds(node, ids = new Set()) {
+  for (const [name, value] of node.attrs) {
+    if (name === 'id') {
+      ids.add(value);
+    }
+  }
+  for (const child of node.children) {
+    collectIds(child, ids);
+  }
+  return ids;
+}
+
+/** Converts one SVG source file into an Iconify icon record. */
+function toIconifyIcon(svgText, iconName, mono) {
+  const root = parseSvg(svgText);
+  const viewBox = root.attrs.find(([k]) => k === 'viewBox')?.[1];
+  const [left, top, width, height] = viewBox.split(/\s+/).map(Number);
+  const ids = collectIds(root);
+  if (ids.size > 0) {
+    namespaceIds(root, iconName, ids);
+  }
+  let body = root.children.map(child => serializeSvg(child)).join('');
+  if (mono) {
+    // Our mono SVGs rely on a root fill="currentColor"; Iconify keeps only
+    // the body, so re-establish inheritance with a wrapping group.
+    body = `<g fill="currentColor">${body}</g>`;
+  }
+  const icon = { body, width, height };
+  if (left !== 0) {
+    icon.left = left;
+  }
+  if (top !== 0) {
+    icon.top = top;
+  }
+  return icon;
+}
+
+export function buildIconifySets() {
+  const sets = {
+    colored: {
+      prefix: 'web3',
+      info: {
+        name: 'React Web3 Icons',
+        total: 0,
+        author: {
+          name: 'derodero24',
+          url: 'https://github.com/derodero24/react-web3-icons',
+        },
+        license: {
+          title: 'MIT',
+          spdx: 'MIT',
+          url: 'https://github.com/derodero24/react-web3-icons/blob/main/LICENSE',
+        },
+        samples: ['chain-ethereum', 'coin-bitcoin', 'wallet-meta-mask'],
+        height: 24,
+        palette: true,
+      },
+      icons: {},
+      aliases: {},
+    },
+    mono: {
+      prefix: 'web3-mono',
+      info: {
+        name: 'React Web3 Icons Mono',
+        total: 0,
+        author: {
+          name: 'derodero24',
+          url: 'https://github.com/derodero24/react-web3-icons',
+        },
+        license: {
+          title: 'MIT',
+          spdx: 'MIT',
+          url: 'https://github.com/derodero24/react-web3-icons/blob/main/LICENSE',
+        },
+        samples: [
+          'chain-ethereum-mono',
+          'coin-bitcoin-mono',
+          'wallet-meta-mask-mono',
+        ],
+        height: 24,
+        palette: false,
+      },
+      icons: {},
+      aliases: {},
+    },
+  };
+
+  // First pass: artwork units → icons, keyed for alias resolution.
+  const iconNameByExport = new Map(); // `${category}/${ExportName}` → iconify name
+  const unitsByCategory = new Map();
+  for (const category of CATEGORIES) {
+    const units = loadCategory(ICONS, category);
+    unitsByCategory.set(category, units);
+    for (const unit of units) {
+      const { meta, svgs } = unit;
+      if (meta.kind !== 'icon' && meta.kind !== 'custom') {
+        continue;
+      }
+      for (const [suffix, variant] of Object.entries(meta.variants)) {
+        const exportName = meta.name + suffix;
+        const mono = suffix.endsWith('Mono');
+        const set = mono ? sets.mono : sets.colored;
+        const iconName = `${category}-${kebab(exportName)}`;
+        set.icons[iconName] = toIconifyIcon(svgs[suffix], iconName, mono);
+        if (meta.deprecated?.[exportName]) {
+          set.icons[iconName].hidden = true;
+        }
+        iconNameByExport.set(`${category}/${exportName}`, iconName);
+      }
+    }
+  }
+
+  // Second pass: alias/re-export names → Iconify aliases.
+  const pendingLinks = [];
+  const categoryOf = (spec, current) =>
+    /^\.\.\/([a-z]+)\//.exec(spec)?.[1] ?? current;
+  for (const [category, units] of unitsByCategory) {
+    for (const unit of units) {
+      const { meta } = unit;
+      const links = [];
+      if (meta.reexport) {
+        const refCat = categoryOf(meta.reexport.from, category);
+        for (const { of, as } of meta.reexport.exports) {
+          links.push({ name: as, target: `${refCat}/${of}`, hidden: false });
+        }
+      }
+      if (meta.aliasConst) {
+        const refCat = categoryOf(meta.aliasConst.importFrom, category);
+        for (const e of meta.aliasConst.exports) {
+          links.push({
+            name: e.name,
+            target: `${refCat}/${e.target}`,
+            hidden: Boolean(e.deprecated),
+          });
+        }
+      }
+      for (const a of meta.localAliases ?? []) {
+        links.push({
+          name: a.name,
+          target: `${category}/${a.target}`,
+          hidden: Boolean(a.deprecated),
+        });
+      }
+      for (const link of links) {
+        pendingLinks.push({ category, ...link });
+      }
+    }
+  }
+
+  // Resolve alias chains (e.g. Matic → Pol → Polygon) over multiple rounds.
+  let progressed = true;
+  while (progressed && pendingLinks.length > 0) {
+    progressed = false;
+    for (let i = pendingLinks.length - 1; i >= 0; i--) {
+      const link = pendingLinks[i];
+      const parent = iconNameByExport.get(link.target);
+      if (!parent) {
+        continue;
+      }
+      const mono = link.name.endsWith('Mono');
+      const set = mono ? sets.mono : sets.colored;
+      const aliasName = `${link.category}-${kebab(link.name)}`;
+      set.aliases[aliasName] = link.hidden
+        ? { parent, hidden: true }
+        : { parent };
+      iconNameByExport.set(`${link.category}/${link.name}`, parent);
+      pendingLinks.splice(i, 1);
+      progressed = true;
+    }
+  }
+  if (pendingLinks.length > 0) {
+    throw new Error(
+      `unresolved iconify aliases: ${pendingLinks.map(l => `${l.category}/${l.name}`).join(', ')}`,
+    );
+  }
+
+  sets.colored.info.total = Object.keys(sets.colored.icons).length;
+  sets.mono.info.total = Object.keys(sets.mono.icons).length;
+  return sets;
+}
+
+if (import.meta.url === (await import('node:url')).pathToFileURL(process.argv[1]).href) {
+  const sets = buildIconifySets();
+  writeFileSync(
+    join(ROOT, 'dist/iconify.json'),
+    `${JSON.stringify(sets.colored)}\n`,
+  );
+  writeFileSync(
+    join(ROOT, 'dist/iconify-mono.json'),
+    `${JSON.stringify(sets.mono)}\n`,
+  );
+  console.log(
+    `dist/iconify.json (${sets.colored.info.total} icons, ${Object.keys(sets.colored.aliases).length} aliases) and dist/iconify-mono.json (${sets.mono.info.total} icons, ${Object.keys(sets.mono.aliases).length} aliases) written.`,
+  );
+}

--- a/test/iconify.test.ts
+++ b/test/iconify.test.ts
@@ -1,0 +1,57 @@
+import { quicklyValidateIconSet } from '@iconify/utils';
+import { describe, expect, it } from 'vitest';
+// @ts-expect-error — plain .mjs pipeline module without type declarations
+import { buildIconifySets } from '../scripts/build-icons/emit-iconify.mjs';
+import { ICON_MANIFEST } from '../src/manifest';
+
+const sets = buildIconifySets() as {
+  colored: Record<string, unknown> & {
+    icons: Record<string, { body: string }>;
+    aliases: Record<string, { parent: string }>;
+    info: { total: number };
+  };
+  mono: Record<string, unknown> & {
+    icons: Record<string, { body: string }>;
+    aliases: Record<string, { parent: string }>;
+    info: { total: number };
+  };
+};
+
+describe('IconifyJSON collections', () => {
+  it('both sets pass Iconify validation', () => {
+    expect(quicklyValidateIconSet(sets.colored)).not.toBeNull();
+    expect(quicklyValidateIconSet(sets.mono)).not.toBeNull();
+  });
+
+  it('covers every icon export as an icon or alias', () => {
+    const covered =
+      Object.keys(sets.colored.icons).length +
+      Object.keys(sets.colored.aliases).length +
+      Object.keys(sets.mono.icons).length +
+      Object.keys(sets.mono.aliases).length;
+    expect(covered).toBe(ICON_MANIFEST.length);
+  });
+
+  it('every alias points at an existing icon in its set', () => {
+    for (const set of [sets.colored, sets.mono]) {
+      for (const [name, alias] of Object.entries(set.aliases)) {
+        expect(
+          set.icons[alias.parent],
+          `${name} → ${alias.parent}`,
+        ).toBeDefined();
+      }
+    }
+  });
+
+  it('mono bodies inherit currentColor', () => {
+    for (const [name, icon] of Object.entries(sets.mono.icons)) {
+      expect(icon.body.startsWith('<g fill="currentColor">'), name).toBe(true);
+    }
+  });
+
+  it('internal ids are namespaced per icon', () => {
+    const icon = sets.mono.icons['chain-ethereum-circle-mono'];
+    expect(icon?.body).toContain('id="chain-ethereum-circle-mono-ethc-a"');
+    expect(icon?.body).toContain('url(#chain-ethereum-circle-mono-ethc-a)');
+  });
+});


### PR DESCRIPTION
## Summary

Implements the emitter half of #702 — with the SVG-first pipeline (#733) this is exactly the "one more emitter over the same source" it was re-scoped to be:

- **`react-web3-icons/iconify.json`** — 301 colored icons, prefix `web3`, `palette: true` (500 KB)
- **`react-web3-icons/iconify-mono.json`** — 290 `currentColor` icons, prefix `web3-mono`, `palette: false` (374 KB)
- Icon names: `<category>-<kebab-name>` (`chain-ethereum`, `wallet-meta-mask`); the 78 ticker/deprecated re-exports become **Iconify aliases** (deprecated → `hidden`), with multi-round resolution for alias chains (`Matic → Pol → Polygon`)
- Internal svg ids are namespaced per icon name (Iconify inlines bodies, so page-level collisions matter); mono bodies are wrapped in `<g fill="currentColor">` since Iconify drops our root fill; non-zero viewBox origins map to Iconify `left`/`top`
- Emission runs in `pnpm run build`; `info` blocks carry the metadata (name/author/license/samples) the icon-sets submission requires

**Guards** (`test/iconify.test.ts`): both sets pass `@iconify/utils` `quicklyValidateIconSet`; icons+aliases across both sets cover exactly all 669 manifest entries; every alias resolves within its set; every mono body inherits `currentColor`; id namespacing verified on a mask-based sample.

This immediately enables local Iconify usage in any framework (`addCollection` + `@iconify/react`/vue/svelte, `unplugin-icons`) — documented in a new README section. **Remaining for #702**: the external submission PR to `iconify/icon-sets` (and the final prefix choice, which is the maintainer's call — `web3` is a placeholder that can be renamed in one constant).

## Related issue

Part of #702

## Icon source verification (required for icon add/update PRs)

N/A — no artwork changes; bodies are derived from the existing `icons/` sources.

## Breaking changes / Deprecations

None — additive subpaths.

## Checklist

- [x] Lint passes (`pnpm run check`)
- [x] Tests pass (`pnpm test`) — 5,236 passed
- [x] Build succeeds (`pnpm run build`)
- [x] Changeset included (if `src/` changed): minor changeset included
- [x] Official icon source and usage context documented above (or N/A)
- [x] Default icon geometry/colors match official asset (or N/A)
- [x] Compare page updated if library features changed (README section added)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FaQCzvxapyUZ3vgJurLa7H

---
_Generated by [Claude Code](https://claude.ai/code/session_01FaQCzvxapyUZ3vgJurLa7H)_