### PR TITLE
fix(example): resolve react-web3-icons/manifest without a prebuilt dist (repairs Vercel deploy)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -92,9 +92,10 @@ jobs:
       - name: Install deps
         run: pnpm install --frozen-lockfile
 
-      - name: Build library
-        run: pnpm run build
-
+      # Intentionally no library build: Vercel deploys the example with only
+      # `next build` (see example/vercel.json), resolving the workspace
+      # package from source via next.config/tsconfig aliases. Building dist
+      # here would mask missing-alias failures that then break deploys.
       - name: Build example app
         run: pnpm --filter react-web3-icons-example run build
 

--- a/example/next-env.d.ts
+++ b/example/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/dev/types/routes.d.ts";
+import "./.next/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/example/next.config.ts
+++ b/example/next.config.ts
@@ -8,8 +8,13 @@ const nextConfig: NextConfig = {
     resolveAlias: {
       // Resolve the workspace package to its TypeScript source so Next.js
       // can transpile it directly without requiring a pre-built dist/.
+      // Every subpath imported by the example needs BOTH an entry here and
+      // one in tsconfig.json "paths" — Vercel builds without dist, so a
+      // missing alias fails the deploy (CI reproduces this: the example job
+      // builds without the library dist).
       'react-web3-icons': '../src/index.ts',
       'react-web3-icons/meta': '../src/meta/index.ts',
+      'react-web3-icons/manifest': '../src/manifest/index.ts',
     },
   },
 };

--- a/example/tsconfig.json
+++ b/example/tsconfig.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "paths": {
       "react-web3-icons": ["../src/index.ts"],
-      "react-web3-icons/meta": ["../src/meta/index.ts"]
+      "react-web3-icons/meta": ["../src/meta/index.ts"],
+      "react-web3-icons/manifest": ["../src/manifest/index.ts"]
     },
     "module": "ESNext",
     "moduleResolution": "Bundler",


### PR DESCRIPTION
## Summary

Fixes the Vercel preview-deploy failure introduced by #737.

**Root cause**: the example app resolves the workspace package **from TypeScript source** (Turbopack `resolveAlias` + tsconfig `paths`) because Vercel runs only `next build` with no library dist. #737 added `import { ICON_MANIFEST } from 'react-web3-icons/manifest'` to `useIconFilter`, and that subpath had no alias — on Vercel it fell through to the package `exports` map pointing at a nonexistent `dist/manifest/index.mjs`. Reproduced locally by deleting `dist/` (`Module not found: Can't resolve 'react-web3-icons/manifest'`, then the matching tsc error).

**Why CI missed it**: the `Build example app` job prebuilt the library dist first, so resolution succeeded in CI while failing on Vercel.

**Fix**:
- Add the `react-web3-icons/manifest` alias to `example/next.config.ts` and `example/tsconfig.json` — verified: `next build` now succeeds with `dist/` deleted
- Align CI with the deploy environment: the example job no longer prebuilds the library, so any future missing alias fails CI instead of only surfacing as a deploy email
- Document the alias contract in `next.config.ts`

Merging this redeploys `develop` on Vercel and clears the failure; this PR's own preview deployment exercises the fix directly.

## Related issue

Follow-up to #737 (Vercel deploy failure reported by email).

## Icon source verification (required for icon add/update PRs)

N/A

## Breaking changes / Deprecations

N/A

## Checklist

- [x] Lint passes (`pnpm run check`)
- [x] Tests pass (`pnpm test`) — 5,237 passed
- [x] Build succeeds (`pnpm run build`) — and example builds **without** dist
- [x] Changeset included (if `src/` changed): N/A — example/CI only
- [x] Official icon source and usage context documented above (or N/A)
- [x] Default icon geometry/colors match official asset (or N/A)
- [x] Compare page updated if library features changed (N/A)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FaQCzvxapyUZ3vgJurLa7H

---
_Generated by [Claude Code](https://claude.ai/code/session_01FaQCzvxapyUZ3vgJurLa7H)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **改善**
  * 例アプリのビルド構成を見直し、不要なライブラリビルドを行わずにアプリをビルド・デプロイできるようにしました。
  * `manifest` サブパスを例アプリから参照できるようになり、ビルド環境での動作が安定しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->