### PR TITLE
docs: document Node 20 drop in migration guide, link it from README

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -38,11 +38,16 @@ Internal `id` attributes (masks, gradients) previously used React's `useId` and 
 - Rendering the same icon multiple times on one page duplicates those ids. The duplicate definitions are identical, so icons render correctly — but if your tooling requires globally unique DOM ids, render such icons once and reuse via CSS.
 - Markup snapshots that captured the old `useId`-based values need to be regenerated.
 
+## 3. Node.js 20 support dropped
+
+`engines.node` is now `>=22.12.0`. Node 20 reached end-of-life on 2026-04-30. This only affects the declared support matrix — the published files are plain ESM and unchanged — but package managers will warn (or fail, with `engine-strict`) when installing on Node 20. Browsers and bundlers are unaffected.
+
 ## Checklist
 
 - [ ] Replace `IconContext.Provider` usages (font-size wrapper or explicit props)
 - [ ] Remove `IconContextValue` type imports
 - [ ] Regenerate any markup snapshots containing icon defs ids
+- [ ] Ensure CI/deploy environments run Node 22.12+ (if they install with `engine-strict`)
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -45,6 +45,8 @@ yarn add react-web3-icons
 pnpm add react-web3-icons
 ```
 
+Requires React 18+ (Node.js 22.12+ when rendering on the server). Upgrading from v3? See the [migration guide](./MIGRATION.md).
+
 ## Quick Start
 
 [![Open in StackBlitz](https://developer.stackblitz.com/img/open_in_stackblitz.svg)][stackblitz-url]


### PR DESCRIPTION
## Summary

Pre-release documentation pass for v4.0.0:

- **MIGRATION.md**: the v3→v4 section now covers all three breaking changes — the Node 20 drop from #739 was missing (only `IconContext` removal and deterministic ids were documented). Adds the consumer impact (`engine-strict` installs fail on Node 20; plain installs warn) and a checklist item for CI/deploy environments.
- **README** (Install section): adds the React 18+ / Node 22.12+ floors and a pointer to the migration guide, so v3 users landing on npm find the upgrade path immediately.

Part of the final pre-release verification for #721. No code changes; no changeset needed (docs only).

## Related issue

Follow-up to #739 / #693.

## Icon source verification (required for icon add/update PRs)

N/A

## Breaking changes / Deprecations

N/A — documentation only.

## Checklist

- [x] Lint passes (`pnpm run check`)
- [x] Tests pass (`pnpm test`)
- [x] Build succeeds (`pnpm run build`)
- [x] Changeset included (if `src/` changed): N/A — docs only
- [x] Official icon source and usage context documented above (or N/A)
- [x] Default icon geometry/colors match official asset (or N/A)
- [x] Compare page updated if library features changed (N/A)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FaQCzvxapyUZ3vgJurLa7H

---
_Generated by [Claude Code](https://claude.ai/code/session_01FaQCzvxapyUZ3vgJurLa7H)_