### PR TITLE
fix(renovate): gate updates on a 3-day release age to match pnpm policy

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -8,6 +8,7 @@
     "before 4am on monday"
   ],
   "prConcurrentLimit": 10,
+  "minimumReleaseAge": "3 days",
   "lockFileMaintenance": {
     "enabled": true,
     "automerge": true,


### PR DESCRIPTION
## Summary

Root-cause fix for today's Vercel preview-deploy failure email.

**What happened**: after #739 pinned tsdown at 0.22.7, Renovate rebased its open tsdown PR (#682) to 0.22.8 — but 0.22.8 was published ~30h ago, and pnpm's supply-chain policy (`.npmrc` `minimum-release-age=4320`, 3 days) blocked Renovate's own lockfile update. The rebased branch shipped `package.json` at 0.22.8 with the lockfile still at 0.22.7, so **every** `pnpm install --frozen-lockfile` on that branch fails with `ERR_PNPM_OUTDATED_LOCKFILE` — that made #682's CI red and produced the Vercel deploy-failure email (Vercel builds a preview for every branch, including `renovate/tsdown-0.x`). `develop` and the demo site were never affected.

**Fix**: set Renovate's `minimumReleaseAge` to the same `3 days`, so Renovate stops proposing versions pnpm refuses to resolve. Young releases now sit as "pending" on the dependency dashboard until they mature, then flow through the normal automerge path. After this merges, #682 should reconcile on Renovate's next run (0.22.8 matures 2026-07-18 ~07:00 UTC).

## Related issue

Follow-up to #739; fixes the failure mode behind today's deploy-failure email (second occurrence, unrelated to the first one fixed in #738).

## Icon source verification (required for icon add/update PRs)

N/A

## Breaking changes / Deprecations

N/A — repository automation config only.

## Checklist

- [x] Lint passes (`pnpm run check`)
- [x] Tests pass (`pnpm test`)
- [x] Build succeeds (`pnpm run build`)
- [x] Changeset included (if `src/` changed): N/A — config only
- [x] Official icon source and usage context documented above (or N/A)
- [x] Default icon geometry/colors match official asset (or N/A)
- [x] Compare page updated if library features changed (N/A)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FaQCzvxapyUZ3vgJurLa7H

---
_Generated by [Claude Code](https://claude.ai/code/session_01FaQCzvxapyUZ3vgJurLa7H)_